### PR TITLE
FIX: Add python3-aiofiles package

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 - **Python**: Version 3.x
 - **Dependencies**:
   ```bash
-  git, python3-flask, python3-requests, python3-sklearn, python3-pandas, python3-numpy
+  git, python3-flask, python3-requests, python3-sklearn, python3-pandas, python3-numpy, python3-aiofiles
   ```
 
 ## 🛠️ Installation

--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,7 @@ check_software() {
         log "INFO" "Python3 is installed." "$CHECKMARK"
     fi
 
-    REQUIRED_SYSTEM_PACKAGES=("git" "python3-flask" "python3-requests" "python3-sklearn" "python3-pandas" "python3-numpy")
+    REQUIRED_SYSTEM_PACKAGES=("git" "python3-flask" "python3-requests" "python3-sklearn" "python3-pandas" "python3-numpy" "python3-aiofiles")
 
     for package in "${REQUIRED_SYSTEM_PACKAGES[@]}"; do
         if dpkg -l | grep -qw "$package"; then


### PR DESCRIPTION
Hey,

I set this project up today and was running in this error with `lxc_monitor.service`

```logtalk
Sep 29 14:13:28 python3[2062397]: Traceback (most recent call last):
Sep 29 14:13:28 python3[2062397]:   File "/usr/local/bin/lxc_monitor.py", line 12, in <module>
Sep 29 14:13:28 python3[2062397]:     import aiofiles
Sep 29 14:13:28 python3[2062397]: ModuleNotFoundError: No module named 'aiofiles'
Sep 29 14:13:28 systemd[1]: lxc_monitor.service: Main process exited, code=exited, status=1/FAILURE
```

This PR is fixes that error on my setup.