### PR TITLE
Prevent YAML parsing of empty files

### DIFF
--- a/lxc_autoscale_ml/model/config_manager.py
+++ b/lxc_autoscale_ml/model/config_manager.py
@@ -13,6 +13,9 @@ def load_config(config_path, default_config=None):
     try:
         with open(config_path, 'r') as file:
             config = yaml.safe_load(file)
+            if config is None:
+                logging.error(f"Configuration file is empty: {config_path}")
+                raise ConfigError("Configuration file is empty")
             logging.info(f"Configuration loaded from {config_path}")
     except yaml.YAMLError as e:
         logging.error(f"Error parsing YAML file: {e}")


### PR DESCRIPTION
### FabGPT — code quality

**File:** `lxc_autoscale_ml/model/config_manager.py`

**Rationale:** The current code attempts to parse an empty file with `yaml.safe_load()`, which returns `None`. This causes the subsequent logic to fail when checking for required keys, resulting in confusing error messages about missing keys rather than a clear indication that the file is empty. Adding a check for `None` immediately after parsing ensures a specific, actionable error is raised for empty configuration files.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen/qwen3.5-9b` · task `ace42c75298127fd` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"ace42c75298127fd","source":"quality","model":"qwen/qwen3.5-9b","severity":"INFO","iterations":1,"inference_s":69.56,"prompt_sha":"6cd572cf1125fd1d","triage":"INFO"} -->