### PR TITLE
Fix race condition in in-memory rate limiter

### DIFF
--- a/lxc_autoscale_ml/api/rate_limiting.py
+++ b/lxc_autoscale_ml/api/rate_limiting.py
@@ -1,9 +1,12 @@
 from functools import wraps
 from flask import request, jsonify, current_app
 import time
+import threading
 
 # Simple in-memory rate limiting for demonstration purposes
 rate_limit_data = {}
+# Lock to ensure thread-safe access to the shared rate_limit_data dictionary
+_rate_limit_lock = threading.Lock()
 
 def rate_limit(f):
     """
@@ -14,6 +17,7 @@ def rate_limit(f):
     - Per-IP tracking with sliding window
     - Configurable limits per endpoint
     - Clear error messages with retry-after header
+    - Thread-safe access to shared state
     """
     @wraps(f)
     def decorated_function(*args, **kwargs):
@@ -28,47 +32,46 @@ def rate_limit(f):
         if not rate_limiting_config.get('enabled', True):
             return f(*args, **kwargs)
 
-        if client_ip not in rate_limit_data:
-            rate_limit_data[client_ip] = []
-
-        access_times = rate_limit_data[client_ip]
         current_time = time.time()
-        
-        # Configurable time window (default 60 seconds)
         time_window = rate_limiting_config.get('time_window_seconds', 60)
-
-        # Filter out access times that are older than the time window
-        access_times = [t for t in access_times if current_time - t < time_window]
-        rate_limit_data[client_ip] = access_times
-        
         max_requests = rate_limiting_config.get('max_requests_per_minute', 60)
+        
+        with _rate_limit_lock:
+            if client_ip not in rate_limit_data:
+                rate_limit_data[client_ip] = []
 
-        if len(access_times) >= max_requests:
-            # Calculate retry-after time
-            oldest_request = min(access_times)
-            retry_after = int(time_window - (current_time - oldest_request)) + 1
+            access_times = rate_limit_data[client_ip]
             
-            response = jsonify({
-                "status": "error",
-                "error": "Rate limit exceeded. Please try again later.",
-                "retry_after_seconds": retry_after,
-                "limit": max_requests,
-                "window_seconds": time_window
-            })
-            response.headers['Retry-After'] = str(retry_after)
-            response.headers['X-RateLimit-Limit'] = str(max_requests)
-            response.headers['X-RateLimit-Remaining'] = '0'
-            response.headers['X-RateLimit-Reset'] = str(int(oldest_request + time_window))
-            return response, 429
+            # Filter out access times that are older than the time window
+            access_times = [t for t in access_times if current_time - t < time_window]
+            rate_limit_data[client_ip] = access_times
+            
+            if len(access_times) >= max_requests:
+                # Calculate retry-after time
+                oldest_request = min(access_times)
+                retry_after = int(time_window - (current_time - oldest_request)) + 1
+                
+                response = jsonify({
+                    "status": "error",
+                    "error": "Rate limit exceeded. Please try again later.",
+                    "retry_after_seconds": retry_after,
+                    "limit": max_requests,
+                    "window_seconds": time_window
+                })
+                response.headers['Retry-After'] = str(retry_after)
+                response.headers['X-RateLimit-Limit'] = str(max_requests)
+                response.headers['X-RateLimit-Remaining'] = '0'
+                response.headers['X-RateLimit-Reset'] = str(int(oldest_request + time_window))
+                return response, 429
 
-        access_times.append(current_time)
-        
-        # Add rate limit headers to successful responses
-        response = f(*args, **kwargs)
-        if hasattr(response, 'headers'):
-            response.headers['X-RateLimit-Limit'] = str(max_requests)
-            response.headers['X-RateLimit-Remaining'] = str(max_requests - len(access_times))
-        
-        return response
+            access_times.append(current_time)
+            
+            # Add rate limit headers to successful responses
+            response = f(*args, **kwargs)
+            if hasattr(response, 'headers'):
+                response.headers['X-RateLimit-Limit'] = str(max_requests)
+                response.headers['X-RateLimit-Remaining'] = str(max_requests - len(access_times))
+            
+            return response
     
     return decorated_function


### PR DESCRIPTION
### FabGPT — code quality

**File:** `lxc_autoscale_ml/api/rate_limiting.py`

**Rationale:** The current implementation is not thread-safe; concurrent requests from the same IP can read stale data and append timestamps without locking, causing the rate limit count to be inaccurate under load. This leads to either false positives (blocking valid users) or false negatives (allowing too many requests), breaking the reliability of the API.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen/qwen3.5-9b` · task `03cc31e95a15b274` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"03cc31e95a15b274","source":"quality","model":"qwen/qwen3.5-9b","severity":"WARN","iterations":1,"inference_s":51.49,"prompt_sha":"119961c1b5d4ef8e","triage":"WARN"} -->