### PR TITLE
Bump requests to 2.33.0 (medium)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==3.0.0
-requests==2.32.4
+requests==2.33.0
 aiohttp==3.13.3  # For async API calls
 scikit-learn==1.5.0
 pandas==2.1.4


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `requests` `2.32.4` → `2.33.0`
**Manifest:** `requirements.txt`
**Severity:** medium
**Advisory:** Requests has Insecure Temp File Reuse in its extract_zipped_paths() utility function CVE-2026-25645

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `884bbc393a3999bb` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"884bbc393a3999bb","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->