### PR TITLE
Safely access RATE_LIMITING config to avoid KeyError

### DIFF
--- a/lxc_autoscale_ml/api/rate_limiting.py
+++ b/lxc_autoscale_ml/api/rate_limiting.py
@@ -22,13 +22,14 @@ def rate_limit(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
         client_ip = request.remote_addr
-        rate_limiting_config = current_app.config['RATE_LIMITING']
+        # Use .get with a default to avoid KeyError if the config is missing
+        rate_limiting_config = current_app.config.get('RATE_LIMITING', {})
         
         # Exempt localhost - ML service makes many requests
         if client_ip in ['127.0.0.1', '::1', 'localhost']:
             return f(*args, **kwargs)
         
-        # Check if rate limiting is disabled
+        # Check if rate limiting is disabled (default to enabled when config missing)
         if not rate_limiting_config.get('enabled', True):
             return f(*args, **kwargs)
 


### PR DESCRIPTION
### FabGPT — code quality

**File:** `lxc_autoscale_ml/api/rate_limiting.py`

**Rationale:** The decorator directly indexes `current_app.config['RATE_LIMITING']`, which raises a KeyError if the configuration key is missing, causing unexpected 500 errors. Using `dict.get` with a default ensures the rate limiting logic degrades gracefully and maintains service stability.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `gpt-oss-120b` · task `03cc31e95a15b274` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"03cc31e95a15b274","source":"quality","model":"gpt-oss-120b","severity":"WARN","iterations":2,"inference_s":28.02,"prompt_sha":"0f849d5bbc48525c","triage":"WARN"} -->