### PR TITLE
Fix command injection in check_vm_status

### DIFF
--- a/lxc_autoscale_ml/api/resource_checking.py
+++ b/lxc_autoscale_ml/api/resource_checking.py
@@ -3,7 +3,7 @@ from utils import create_response, handle_error
 
 def check_vm_status(vm_id):
     try:
-        result = subprocess.run(f"pct status {vm_id}", shell=True, capture_output=True, text=True)
+        result = subprocess.run(["pct", "status", vm_id], capture_output=True, text=True)
         return create_response(data=result.stdout.strip(), message=f"Resource status retrieved for container {vm_id}")
     except Exception as e:
         return handle_error(e)


### PR DESCRIPTION
### FabGPT — security

**File:** `lxc_autoscale_ml/api/resource_checking.py` (line 6)
**Class:** command injection — detected: f-string into a shell command

**Rationale:** The vulnerability arises from using f-strings with user-controlled input (vm_id) directly in a shell command via subprocess.run with shell=True, allowing command injection. The fix replaces shell interpolation with a parameterized list of arguments, removing shell interpretation and ensuring vm_id is passed safely as a positional argument.

_Static-detected, LLM-fixed; reviewed by a human before opening._

---
🤖 **FabGPT OS** · source `security` · model `qwen3-coder-next` · task `7d8b0f886801dc77` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"7d8b0f886801dc77","source":"security","model":"qwen3-coder-next","severity":"WARN","iterations":1,"inference_s":4.37,"triage":"WARN"} -->