### PR TITLE
Fix command injection in check_node_status

### DIFF
--- a/lxc_autoscale_ml/api/resource_checking.py
+++ b/lxc_autoscale_ml/api/resource_checking.py
@@ -10,7 +10,7 @@ def check_vm_status(vm_id):
 
 def check_node_status(node_name):
     try:
-        result = subprocess.run(f"pvesh get /nodes/{node_name}/status", shell=True, capture_output=True, text=True)
+        result = subprocess.run(["pvesh", "get", f"/nodes/{node_name}/status"], capture_output=True, text=True)
         return create_response(data=result.stdout.strip(), message=f"Resource status retrieved for node '{node_name}'")
     except Exception as e:
         return handle_error(e)


### PR DESCRIPTION
### FabGPT — security

**File:** `lxc_autoscale_ml/api/resource_checking.py` (line 13)
**Class:** command injection — detected: f-string into a shell command

**Rationale:** The vulnerability is a command injection risk caused by using f-string interpolation with user-controlled input (node_name) directly in a shell command via subprocess.run(..., shell=True). An attacker could inject arbitrary shell commands through the node_name parameter. The fix removes shell=True and passes the command and arguments as a list, ensuring node_name is treated strictly as an argument and not interpreted as shell code.

_Static-detected, LLM-fixed; reviewed by a human before opening._

---
🤖 **FabGPT OS** · source `security` · model `qwen3-coder-next` · task `7d8b0f886801dc77` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"7d8b0f886801dc77","source":"security","model":"qwen3-coder-next","severity":"WARN","iterations":1,"inference_s":4.62,"triage":"WARN"} -->