### PR TITLE
Bump aiohttp to 3.14.1 (medium)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==3.0.0
 requests==2.33.0
-aiohttp==3.13.3  # For async API calls
+aiohttp==3.14.1  # For async API calls
 scikit-learn==1.5.0
 pandas==2.1.4
 numpy==1.26.2


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `aiohttp` `3.13.3` → `3.14.1`
**Manifest:** `requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-22815, CVE-2026-34513, CVE-2026-34514, CVE-2026-34515, CVE-2026-34516, CVE-2026-34517, CVE-2026-34518, CVE-2026-34519, CVE-2026-34520, CVE-2026-34525, CVE-2026-34993, CVE-2026-47265, CVE-2026-50269, CVE-2026-54273, CVE-2026-54274, CVE-2026-54275, CVE-2026-54276, CVE-2026-54277, CVE-2026-54278, CVE-2026-54279, CVE-2026-54280

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `e54f15eca0cf9b68` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"e54f15eca0cf9b68","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->