### PR TITLE
privacy: link the shared privacy notice + meta-CSP

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,6 +6,18 @@ export default defineConfig({
   base: '/proxmox-lxc-autoscale-ml/',
 
   head: [
+    // Tutto first-party. 'unsafe-inline' serve perche' VitePress emette
+    // uno script inline per il tema e stili inline.
+    [
+      'meta',
+      {
+        'http-equiv': 'Content-Security-Policy',
+        content:
+          "default-src 'self'; script-src 'self' 'unsafe-inline'; " +
+          "style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
+          "font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'",
+      },
+    ],
     ['link', { rel: 'icon', type: 'image/png', href: '/favicon.png' }],
     ['meta', { name: 'theme-color', content: '#3eaf7c' }],
     ['meta', { name: 'og:type', content: 'website' }],
@@ -96,7 +108,7 @@ export default defineConfig({
     ],
 
     footer: {
-      message: 'Released under the MIT License.',
+      message: 'Released under the MIT License.' + ' · <a href="https://fabriziosalmi.github.io/privacy">Privacy &amp; legal</a>',
       copyright: 'Copyright 2024 Fabrizio Salmi'
     },
 


### PR DESCRIPTION
This project site had **no privacy notice**. Rather than adding another copy, it now links the canonical notice published once for every project site on this host:

### 🔗 https://fabriziosalmi.github.io/privacy

That notice is accurate for this site as-is — same publisher, same host (GitHub Pages), no cookies, no analytics, and the only device storage is the VitePress light/dark preference, which the notice describes. One document to maintain instead of ~25 copies drifting apart.

## Changes (one file, two additions)
- **`themeConfig.footer`** — a `Privacy & legal` link. VitePress renders the footer on the hero home page too, so it is reachable from **every** page without touching the nav.
- **`head`** — meta-CSP, `default-src 'self'`. `'unsafe-inline'` is required because VitePress emits an inline appearance script and inline styles.

## Verified
The same transform was applied across all the VitePress sites and validated by building **one representative of each config shape** (footer/head already present, created, or both) — all built clean, and the output HTML carries the link on both the home and inner pages, plus the CSP. Bracket balance checked on every config.

Pattern approved in fabriziosalmi/gitoma#48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)