### PR TITLE
review: scope the CSP to production builds + fix comment language

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,18 +6,25 @@ export default defineConfig({
   base: '/proxmox-lxc-autoscale-ml/',
 
   head: [
-    // Tutto first-party. 'unsafe-inline' serve perche' VitePress emette
-    // uno script inline per il tema e stili inline.
-    [
-      'meta',
-      {
-        'http-equiv': 'Content-Security-Policy',
-        content:
-          "default-src 'self'; script-src 'self' 'unsafe-inline'; " +
-          "style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
-          "font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'",
-      },
-    ],
+    // Everything this site loads is first-party. 'unsafe-inline' is required
+    // because VitePress emits an inline appearance script and inline styles.
+    // Applied to the built site only: `vitepress dev` serves HMR over a
+    // websocket, which a strict connect-src would block as soon as the dev
+    // server is not same-origin (--host, or a custom server.hmr.port).
+    ...(process.env.NODE_ENV === 'production'
+      ? [
+          [
+            'meta',
+            {
+              'http-equiv': 'Content-Security-Policy',
+              content:
+                "default-src 'self'; script-src 'self' 'unsafe-inline'; " +
+                "style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
+                "font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'",
+            },
+          ] as [string, Record<string, string>],
+        ]
+      : []),
     ['link', { rel: 'icon', type: 'image/png', href: '/favicon.png' }],
     ['meta', { name: 'theme-color', content: '#3eaf7c' }],
     ['meta', { name: 'og:type', content: 'website' }],
@@ -108,7 +115,8 @@ export default defineConfig({
     ],
 
     footer: {
-      message: 'Released under the MIT License.' + ' · <a href="https://fabriziosalmi.github.io/privacy">Privacy &amp; legal</a>',
+      message: 
+        'Released under the MIT License. · <a href="https://fabriziosalmi.github.io/privacy">Privacy &amp; legal</a>',
       copyright: 'Copyright 2024 Fabrizio Salmi'
     },
 


### PR DESCRIPTION
Follow-up to the privacy/CSP change already merged here, addressing review feedback raised on the same change in `zion` and `proxxx`.

## What changes
1. **Comment language** — the comment inserted next to the CSP was in **Italian** while these configs are English. It came from the script used to roll this out across ~25 repos. Rewritten in English.
2. **CSP scoped to production** — the meta tag was emitted unconditionally, so it also applied under `vitepress dev`.
3. **Footer message** — collapsed back into a single literal where the rollout had left two concatenated ones.

## On the dev-mode concern
I tested it rather than assuming. Under `vitepress dev` the tag *was* injected, but **HMR was not blocked** — the console showed `[vite] connecting...` → `[vite] connected.` and the page hydrated. The dev server and its websocket are same-origin, and `connect-src 'self'` covers that.

It *would* break as soon as the dev server stops being same-origin (`vitepress dev --host`, or a custom `server.hmr.port`), and a CSP is a production concern anyway — so the hardening is applied rather than argued away.

## Verified
Built the `.js` and `.mts` variants of this transform: **CSP present in the built output, absent in dev**, privacy link still rendered on home and inner pages.

**Nothing changes for visitors.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)