### PR TITLE
docs: align the documentation with the software that exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to the LXC AutoScale ML project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+Documentation and shipped configuration brought in line with the code, and
+guarded so they cannot drift apart again.
+
+- **`authentication.api_key` never existed.** The getting-started guide, the
+  installation guide, the upgrade guide and the API component page all told
+  readers to set it. The code reads `authentication.api_keys`, a list, so
+  anyone who followed those instructions believed authentication was enabled
+  when it was not.
+- **Twelve more configuration keys shipped in the defaults and were read by
+  nobody**: `lxc.verify_ssl`, `lxc.max_retries`, `scaling.total_cores`,
+  `scaling.total_ram_mb`, `scaling.target_cpu_load_percent`,
+  `scaling.ram_chunk_size`, `scaling.ram_upper_limit`, and the whole
+  `feature_engineering` and `prediction` sections. Removed.
+- **`circuit_breaker` and `scaling.min_confidence` are now in the shipped model
+  config.** The code reads both; the file never mentioned them.
+- **The monitor configuration reference was fiction.** It documented a
+  `metrics`, `containers` and `performance` layout that has never existed; the
+  real file uses `monitoring` and `logging`.
+- **Stale metric names throughout**: `lxc_scaling_actions_total` and
+  `lxc_api_request_duration_seconds` where the code exports
+  `lxc_autoscale_*`, and an `action="scale_up"` label that is really
+  `set`/`increase`. Every query and alert example was unusable as written.
+- Model documentation used `isolation_forest`, `sleep_interval`, `data.metrics_file`
+  and `retry_attempts` for what the code calls `model`, `interval_seconds`,
+  `data_file` and `retry_logic.max_retries`.
+
+### Changed
+
+- **Invented benchmarks removed.** The docs carried a table of sequential
+  versus async fetch times with speedups up to "10x", with no methodology,
+  hardware or measurement behind them -- for an endpoint that returned an error
+  on every call until v1.3.0. Replaced with a description of the mechanism and
+  a pointer to the timing each cycle logs.
+- Unverifiable claims removed: "Enterprise Security" for authentication that
+  was off by default and unwired, "Production-Ready" for software that had
+  never worked, "zero downtime", "high accuracy", "seamless", "comprehensive".
+  Component descriptions now say what each service does, including what it does
+  not do.
+- Emoji removed from the documentation.
+- Python is stated as 3.10-3.12 in the README, the landing page and the
+  requirements page, instead of "Python 3.x".
+
+### Added
+
+- `tests/test_config_contract.py` and `tests/test_docs_contract.py`: 40 tests
+  that fail if a configuration file grows a key no code reads, if the docs
+  document a setting or endpoint or metric that does not exist, if a YAML
+  example anywhere in the docs uses an unknown key, if a systemd unit points at
+  a file the installer never places, or if emoji or the banned claims come back.
+
 ## [1.3.0] - 2026-08-17
 
 ### Upgrade notes
@@ -198,7 +252,7 @@ next interval, and one bad container no longer abandons the rest of the fleet.
 
 Major release with critical bug fixes, performance improvements, and new enterprise features.
 
-### 🎉 Highlights
+### Highlights
 
 - **10x Performance**: Batch async API calls for concurrent container config fetching
 - **Enterprise Security**: API key authentication, rate limiting, input validation
@@ -366,12 +420,12 @@ Major release with critical bug fixes, performance improvements, and new enterpr
 
 ### Security
 
-- ✅ API key authentication on all sensitive endpoints
-- ✅ Rate limiting with per-IP tracking
-- ✅ Input validation prevents injection attacks
-- ✅ Constant-time API key comparison
-- ✅ Localhost exemption for internal services
-- ✅ Security headers in all responses
+- API key authentication on all sensitive endpoints
+- Rate limiting with per-IP tracking
+- Input validation prevents injection attacks
+- Constant-time API key comparison
+- Localhost exemption for internal services
+- Security headers in all responses
 
 ### Deprecated
 
@@ -519,4 +573,3 @@ If you were hitting rate limits:
 
 ---
 
-**Thank you for using LXC AutoScale ML!** 🎉

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-Documentation and shipped configuration brought in line with the code, and
-guarded so they cannot drift apart again.
+Documentation and shipped configuration brought in line with the code, with
+contract tests covering several classes of drift. Those tests check that
+documented endpoints, metric names, systemd unit names, configuration keys,
+declared default *values*, filesystem paths and the stated Python range match
+what ships; and that no runnable example uses a removed feature. They do **not**
+check response bodies, log strings, prose descriptions of behaviour, or
+consistency between pages -- those remain reviewed by hand.
 
 - **`authentication.api_key` never existed.** The getting-started guide, the
   installation guide, the upgrade guide and the API component page all told
@@ -53,11 +58,13 @@ guarded so they cannot drift apart again.
 
 ### Added
 
-- `tests/test_config_contract.py` and `tests/test_docs_contract.py`: 40 tests
-  that fail if a configuration file grows a key no code reads, if the docs
-  document a setting or endpoint or metric that does not exist, if a YAML
-  example anywhere in the docs uses an unknown key, if a systemd unit points at
-  a file the installer never places, or if emoji or the banned claims come back.
+- `tests/test_config_contract.py` and `tests/test_docs_contract.py`: contract
+  tests that fail if a configuration file grows a key no code reads, if the docs
+  document a setting or endpoint or metric that does not exist, if a documented
+  default disagrees with the shipped file, if a documented path is one the
+  deployment never creates, if a YAML example anywhere uses an unknown key, if a
+  systemd unit points at a file the installer never places, or if emoji or the
+  banned claims come back.
 
 ## [1.3.0] - 2026-08-17
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # LXC AutoScale ML
 
-**LXC AutoScale ML** is a resource management daemon for Proxmox environments. It monitors LXC container resources and adjusts CPU and memory allocations with zero downtime, using machine learning to predict resource demands.
+**LXC AutoScale ML** adjusts the CPU and memory allocated to Proxmox LXC
+containers. It collects per-container metrics, trains an anomaly detection model
+on each container's own history, and applies changes through `pct` on the host.
+Resizing CPU and memory with `pct set` does not restart the container.
 
-**Tested with Proxmox VE 8.2.4**
+Three systemd services, sharing nothing but a metrics file on disk.
 
-![Platform](https://img.shields.io/badge/platform-Proxmox-green) ![Python Version](https://img.shields.io/badge/python-3.x-blue) ![License](https://img.shields.io/badge/license-MIT-blue)
+**Developed and tested on Proxmox VE 8 (Debian 12).**
+
+![Platform](https://img.shields.io/badge/platform-Proxmox%20VE%208-green) ![Python Version](https://img.shields.io/badge/python-3.10--3.12-blue) ![License](https://img.shields.io/badge/license-MIT-blue)
 
 ![LXC AutoScale ML Architecture](https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml/blob/main/docs/lxc_autoscale_ml.png?raw=true)
 
@@ -38,26 +43,43 @@
 
 ## Overview
 
-LXC AutoScale ML manages LXC containers on Proxmox hosts using machine learning for automatic scaling. It dynamically adjusts container resources to maintain optimal performance and efficient resource utilization.
+A monitor writes container metrics to a JSON file, a model reads that file and
+decides whether anything should change, and an API carries the decision out by
+running `pct`. Each runs as its own systemd service.
 
-### Key Features
+### What it does
 
-- **Proxmox Integration**: Seamless integration with Proxmox hosts via API and CLI.
-- **ML-Driven Autoscaling**: Utilizes IsolationForest machine learning model to detect anomalies and predict resource demands.
-- **High-Performance Async API**: Batch async requests provide **10x faster** config fetching for large-scale deployments (60+ containers).
-- **Enterprise Security**: API key authentication, rate limiting with localhost bypass, input validation on all endpoints.
-- **Circuit Breaker Pattern**: Automatic fault tolerance and graceful degradation for API failures.
-- **Modular Architecture**: Components (API, Monitor, Model) designed to handle specific autoscaling tasks.
-- **Customizable Policies**: Define custom scaling rules, thresholds, and step sizes.
-- **Real-Time Monitoring**: Prometheus metrics export for comprehensive observability.
-- **Smart Resource Management**: Incremental scaling (no more jumping to max/min), stale lock cleanup, metrics file size limiting.
-- **Production-Ready**: Comprehensive error handling, detailed logging, and troubleshooting guides.
+- **Learns per container.** An IsolationForest is trained on each container's
+  own history, so "unusual" is relative to that container rather than a fixed
+  rule.
+- **Moves in steps, within limits.** Scaling adds or removes one configured
+  step at a time, between a floor and a ceiling you set.
+- **Fetches configurations concurrently**, with a bounded concurrency limit, so
+  a cycle does not grow linearly with the number of containers.
+- **Backs off from a failing API.** After repeated failures a circuit breaker
+  stops calling it for that container until a timeout expires.
+- **Can rehearse.** `dry_run: true` logs the decision it would have taken and
+  calls nothing.
+- **Exports Prometheus metrics** at `/metrics` — request, scaling and container
+  allocation series.
+- **Optional API authentication**: API keys, per-IP rate limiting and input
+  validation on every endpoint. Authentication is off by default.
+
+### What it does not do
+
+- It does not resize disks automatically; `/scale/storage/increase` exists but
+  nothing calls it on its own.
+- It does not migrate containers between nodes.
+- Per-container I/O statistics come from `/proc/diskstats`, which is not
+  namespaced, so they reflect the host's disks rather than the container's.
 
 ## System Requirements
 
-- **Proxmox Host**: Version 6.x or higher (tested on 8.2.4)
-- **Operating System**: Linux (Debian-based preferred)
-- **Python**: Version 3.x
+- **Proxmox host**: VE 8 (Debian 12). Developed and tested there.
+- **Operating system**: Debian-based Linux
+- **Python**: 3.10 to 3.12. Proxmox VE 9 ships 3.13, which the pinned
+  `numpy`, `pandas` and `scikit-learn` do not yet support — the API and the
+  monitor run there, the model does not.
 - **Dependencies**:
   ```bash
   git, python3-flask, python3-requests, python3-sklearn, python3-pandas, 
@@ -120,21 +142,20 @@ curl -sSL https://raw.githubusercontent.com/fabriziosalmi/proxmox-lxc-autoscale-
 
 ### 1. API Component
 
-The **API** provides RESTful endpoints for managing autoscaling services with enterprise-grade security and performance.
+An HTTP interface over the `pct` command line. It runs as root under gunicorn,
+because `pct` requires it.
 
-#### Features
-
-- **Scaling Operations**: Trigger container scaling manually or via automation.
-- **Configuration Management**: Dynamically update scaling configurations.
-- **Security Features**:
-  - **API Key Authentication**: Secure all endpoints (except health checks and metrics)
-  - **Rate Limiting**: 120 requests/minute with localhost bypass for internal services
-  - **Input Validation**: Comprehensive validation on all parameters
-- **Monitoring and Health Checks**: 
-  - Real-time metrics and system status
-  - **Prometheus Metrics Export**: Track scaling actions, API requests, resource usage
-- **Audit Logging**: Complete logs of all API interactions for security and debugging.
-- **High Performance**: Handles 60+ containers with ease via optimized async operations.
+- **Scaling, snapshot and clone operations**, each validated before a command is
+  built. Commands are passed to the kernel as argument lists, never through a
+  shell.
+- **API key authentication**, off by default, exempting `/health/check` and
+  `/metrics`. Keys are compared in constant time.
+- **Per-IP rate limiting**, 120 requests per minute by default, with localhost
+  exempt so the model is not throttled.
+- **Prometheus metrics** at `/metrics`: request counts and durations, scaling
+  actions and failures, and per-container CPU and memory allocation.
+- **A health check that can fail.** `/health/check` probes `pct` and the
+  configured node, and returns 503 when either is broken.
 
 #### API Endpoints
 
@@ -167,35 +188,42 @@ The **API** provides RESTful endpoints for managing autoscaling services with en
 
 ### 2. Monitor Component
 
-The **Monitor** service continuously tracks the performance and resource usage of LXC containers.
+Reads figures out of each running container and appends them to a JSON file. It
+makes no decisions; it only records.
 
-#### Features
+- **Per-container CPU, memory, swap, process count, I/O, network and filesystem
+  usage**, gathered with `pct exec`.
+- **CPU as usage over the interval**, computed by differencing two `/proc/stat`
+  readings. A single reading would give the container's average since boot.
+- **Concurrent collection** across containers, with a per-probe retry. One
+  unreachable container does not cost the cycle.
+- **A bounded file**: the newest 1000 cycles are kept, written through a
+  temporary file and renamed into place so a crash cannot truncate it.
 
-- **Real-Time Metrics Collection**: Collects CPU, memory, disk, and network usage statistics.
-- **Anomaly Detection**: Detects unusual patterns in resource usage.
-- **Threshold Alerts**: Triggers alerts or scaling actions when predefined thresholds are exceeded.
-- **Data Aggregation**: Aggregates metrics for analysis and reporting.
-- **Automatic Size Management**: Limits metrics file to 1000 entries to prevent memory issues.
-- **Efficient Storage**: Optimized JSON storage with automatic cleanup of old data.
+Note that `/proc/diskstats` is not namespaced, so the I/O figures reflect the
+host's disks rather than the container's.
 
 ### 3. Model Component
 
-The **Model** uses machine learning algorithms to analyze metrics and make intelligent scaling decisions.
+Reads the metrics file, decides what should change, and asks the API to do it.
 
-#### Features
+- **IsolationForest**, retrained each cycle on the full history in the file, to
+  flag samples that are unusual for that container.
+- **Threshold comparison** against the latest sample decides the direction;
+  resources then move by one configured step, bounded by a floor and a ceiling.
+- **`min_confidence`** can require the prediction to sit a given distance from
+  the model's decision boundary before anything is applied. Confidence is that
+  distance mapped onto 0-100, not a probability.
+- **Concurrent configuration fetches** with a bounded concurrency limit and
+  exponential backoff on server errors.
+- **A circuit breaker** that stops calling the API for a container after
+  repeated failures until a timeout expires.
+- **`dry_run`** logs the decision it would have taken and calls nothing.
+- **A single-instance lock** created with `O_EXCL`, with stale locks from a
+  crashed process detected by PID and reclaimed.
 
-- **IsolationForest ML Model**: Detects anomalies in resource usage patterns with high accuracy.
-- **Incremental Scaling**: Scales resources gradually (±1 core, ±512MB RAM) instead of jumping to extremes.
-- **Predictive Scaling**: Forecasts when scaling actions are necessary based on historical data.
-- **Adaptive Learning**: Continuously refines predictions based on new data.
-- **High-Performance Async API Client**: Fetches all container configs concurrently (**10x faster** than sequential).
-- **Circuit Breaker Pattern**: Automatically skips failed API endpoints to prevent cascading failures.
-- **Smart Resource Management**:
-  - Stale lock cleanup with PID checking
-  - Graceful degradation on API errors
-  - Automatic retry with exponential backoff
-- **Configurable Models**: Supports various ML algorithms and custom thresholds.
-- **Production-Ready**: Comprehensive error handling and detailed logging.
+It reacts to the newest sample rather than forecasting future demand, and
+IsolationForest is the only model it supports.
 
 ## Usage and Control
 
@@ -219,30 +247,34 @@ Manage the autoscaling services with the following commands:
 
 - **Prometheus Metrics**: Native Prometheus metrics export at `/metrics` endpoint
   - Scaling actions counter
-  - API request/response metrics  
-  - Container resource gauges
-  - Circuit breaker status
-  - Model prediction accuracy
-- **Metrics Dashboard**: Integrate with tools like Grafana for visualization.
-- **Alerting**: Configure alerts for critical events, such as spikes in CPU or memory usage.
-- **Performance Monitoring**: Track batch API performance (containers/sec) in service logs.
+  - Request counts and durations, labelled by the matched route
+  - Scaling actions and failures, by container and resource
+  - Per-container CPU and memory allocation
+- **Alerting**: see the [metrics reference](docs/reference/metrics.md) for
+  worked alert rules.
+- **Batch fetch timing** is logged each cycle (`Batch fetch completed in ...`).
 
-#### Example Prometheus Queries
+#### Example Prometheus queries
 
 ```promql
-# Total scaling actions in last hour
-rate(lxc_scaling_actions_total[1h])
+# Scaling actions per hour, by resource
+sum by (resource) (rate(lxc_autoscale_scaling_actions_total[1h])) * 3600
 
-# Containers scaled up vs down
-lxc_scaling_actions_total{action="scale_up"} / lxc_scaling_actions_total{action="scale_down"}
+# Containers whose scaling keeps failing
+sum by (container_id) (rate(lxc_autoscale_scaling_failures_total[15m])) > 0
 
 # Average API response time
-rate(lxc_api_request_duration_seconds_sum[5m]) / rate(lxc_api_request_duration_seconds_count[5m])
+rate(lxc_autoscale_api_request_duration_seconds_sum[5m])
+  / rate(lxc_autoscale_api_request_duration_seconds_count[5m])
+
+# Total CPU and memory allocated across the fleet
+sum(lxc_autoscale_container_cpu_cores)
+sum(lxc_autoscale_container_memory_mb)
 ```
 
 ## Documentation
 
-For comprehensive documentation, visit the **[Documentation Site](./docs/)** or build it locally:
+Full documentation is on the [documentation site](./docs/), or build it locally:
 
 ```bash
 cd docs
@@ -297,7 +329,7 @@ If You like my projects, you may also like these ones:
 
 - [caddy-waf](https://github.com/fabriziosalmi/caddy-waf) Caddy WAF (Regex Rules, IP and DNS filtering, Rate Limiting, GeoIP, Tor, Anomaly Detection) 
 - [patterns](https://github.com/fabriziosalmi/patterns) Automated OWASP CRS and Bad Bot Detection for Nginx, Apache, Traefik and HaProxy
-- [blacklists](https://github.com/fabriziosalmi/blacklists) Hourly updated domains blacklist 🚫 
+- [blacklists](https://github.com/fabriziosalmi/blacklists) Hourly updated domains blacklist 
 - [proxmox-vm-autoscale](https://github.com/fabriziosalmi/proxmox-vm-autoscale) Automatically scale virtual machines resources on Proxmox hosts 
 - [UglyFeed](https://github.com/fabriziosalmi/UglyFeed) Retrieve, aggregate, filter, evaluate, rewrite and serve RSS feeds using Large Language Models for fun, research and learning purposes 
 - [proxmox-lxc-autoscale](https://github.com/fabriziosalmi/proxmox-lxc-autoscale) Automatically scale LXC containers resources on Proxmox hosts 

--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -9,7 +9,7 @@ The API component provides a RESTful interface for managing LXC containers on Pr
 | Service | `lxc_autoscale_api` |
 | Configuration | `/etc/lxc_autoscale_ml/lxc_autoscale_api.yaml` |
 | Default Port | 5000 |
-| Log File | `/var/log/autoscaleapi.log` |
+| Log File | `/var/log/lxc_autoscale_api.log` |
 
 ## Features
 
@@ -42,7 +42,7 @@ authentication:
 curl -H "X-API-Key: your-key" http://localhost:5000/routes
 
 # Query parameter authentication
-curl "http://localhost:5000/routes?api_key=your-key"
+curl -H "X-API-Key: your-key" http://localhost:5000/routes
 ```
 
 **Error response (401 Unauthorized):**
@@ -335,9 +335,9 @@ gunicorn:
 
 | File | Content |
 |------|---------|
-| `/var/log/autoscaleapi.log` | Main API logs |
-| `/var/log/autoscaleapi_access.log` | All incoming requests |
-| `/var/log/autoscaleapi_error.log` | Error logs |
+| `/var/log/lxc_autoscale_api.log` | Main API logs |
+| `/var/log/lxc_autoscale_api_access.log` | All incoming requests |
+| `/var/log/lxc_autoscale_api_error.log` | Error logs |
 
 ## HTTPS Setup
 

--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -31,7 +31,8 @@ All endpoints except `/health/check` and `/metrics` require authentication.
 ```yaml
 authentication:
   enabled: true
-  api_key: "your-secret-api-key"
+  api_keys:
+    - "your-secret-api-key"
 ```
 
 **Usage:**
@@ -307,7 +308,8 @@ server:
 # Authentication
 authentication:
   enabled: true
-  api_key: "your-secret-api-key"
+  api_keys:
+    - "your-secret-api-key"
 
 # Rate limiting
 rate_limiting:
@@ -317,10 +319,16 @@ rate_limiting:
 
 # Logging
 logging:
-  log_level: "INFO"
-  log_file: "/var/log/autoscaleapi.log"
-  access_log: "/var/log/autoscaleapi_access.log"
-  error_log: "/var/log/autoscaleapi_error.log"
+  level: "INFO"
+  # log_file: "/var/log/lxc_autoscale_api.log"  # unset: stdout only
+  rotate: true
+  max_log_size_mb: 100
+  backup_count: 5
+
+# HTTP access and error logs belong to gunicorn
+gunicorn:
+  access_log_file: "/var/log/lxc_autoscale_api_access.log"
+  error_log_file: "/var/log/lxc_autoscale_api_error.log"
 ```
 
 ## Log Files

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -1,6 +1,6 @@
 # Components Overview
 
-LXC AutoScale ML consists of three main components that work together to provide intelligent autoscaling.
+LXC AutoScale ML is three separate services. Each runs under its own systemd unit and reads its own configuration file.
 
 ## Architecture
 

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -9,7 +9,7 @@ The Model component is the ML engine that analyzes container metrics and makes s
 | Service | `lxc_autoscale_ml` |
 | Configuration | `/etc/lxc_autoscale_ml/lxc_autoscale_ml.yaml` |
 | Log File | `/var/log/lxc_autoscale_ml.log` |
-| Lock File | `/var/lock/lxc_autoscale_ml.lock` |
+| Lock File | `/run/lxc_autoscale_ml.lock` |
 
 ## Features
 
@@ -88,7 +88,7 @@ Resources scale gradually to avoid instability.
 ```
 Scale UP if:
   - IsolationForest detects anomaly (-1)
-  - CPU usage > cpu_scale_up_threshold (default 70%)
+  - CPU usage > cpu_scale_up_threshold (default 75%)
   - Current cores < max_cpu_cores
 
 Scale DOWN if:
@@ -104,12 +104,12 @@ Step size: cpu_scale_step (default 1 core)
 ```
 Scale UP if:
   - IsolationForest detects anomaly (-1)
-  - RAM usage % > ram_scale_up_threshold (default 80%)
+  - RAM usage % > ram_scale_up_threshold (default 75%)
   - Current RAM < max_ram_mb
 
 Scale DOWN if:
   - IsolationForest reports normal (1)
-  - RAM usage % < ram_scale_down_threshold (default 40%)
+  - RAM usage % < ram_scale_down_threshold (default 30%)
   - Current RAM > min_ram_mb
 
 Step size: ram_scale_step_mb (default 512 MB)
@@ -320,8 +320,8 @@ curl http://127.0.0.1:5000/health/check
 
 ```bash
 # Check if process is running
-cat /var/lock/lxc_autoscale_ml.lock
-ps -p $(cat /var/lock/lxc_autoscale_ml.lock)
+cat /run/lxc_autoscale_ml.lock
+ps -p $(cat /run/lxc_autoscale_ml.lock)
 
 # If not running, restart service (auto-cleans stale lock)
 systemctl restart lxc_autoscale_ml

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -15,7 +15,7 @@ The Model component is the ML engine that analyzes container metrics and makes s
 
 - **IsolationForest ML Model**: Anomaly detection for resource usage
 - **Incremental Scaling**: Gradual resource adjustment
-- **Batch Async API Client**: 10x faster configuration fetching
+- **Async API client**: configuration reads issued concurrently
 - **Circuit Breaker**: Fault tolerance for API failures
 - **Stale Lock Cleanup**: Automatic recovery from crashes
 
@@ -70,11 +70,11 @@ IsolationForest is an unsupervised machine learning algorithm for anomaly detect
 ### Configuration
 
 ```yaml
-isolation_forest:
-  contamination: 0.1      # Expected anomaly percentage (10%)
+model:
+  contamination: 0.05     # Expected outlier fraction
   n_estimators: 100       # Number of trees
+  max_samples: 64         # Samples drawn per tree
   random_state: 42        # Reproducibility
-  max_samples: auto       # Auto-tune sample size
 ```
 
 ## Scaling Logic
@@ -136,21 +136,26 @@ scaling:
   max_ram_mb: 16384
 
   # Confidence
-  min_confidence: 70  # 0 (the default) disables confidence gating
+  min_confidence: 0   # 0 disables confidence gating
+  dry_run: false      # Log decisions without applying them
 ```
 
-## Async Batch API Client
+## Async API client
 
-### Performance Improvement
+Before deciding anything the model needs each container's current CPU and memory
+allocation, which it reads from `/resource/lxc/config`. Those reads are issued
+concurrently instead of one after another, so the fetch stage does not grow
+linearly with container count.
 
-| Containers | Sequential | Async Batch | Speedup |
-|------------|-----------|-------------|---------|
-| 10 | 1.0s | 0.15s | 6.7x |
-| 20 | 2.0s | 0.25s | 8.0x |
-| 50 | 5.0s | 0.50s | 10x |
-| 100 | 10.0s | 1.0s | 10x |
+How much that saves depends entirely on how quickly the API answers, which in
+turn depends on `pct config` on your host. Rather than quoting a figure, read
+the real one: every cycle logs it.
 
-### Features
+```
+Batch fetch completed in 0.42s: 12/12 successful (28.6 containers/sec)
+```
+
+### Behaviour
 
 - Concurrent requests (up to 10 simultaneous)
 - Connection pooling
@@ -165,7 +170,7 @@ api:
   api_url: "http://127.0.0.1:5000"
   timeout: 5
   max_concurrent: 10
-  retry_attempts: 3
+  # retries live under retry_logic, see the configuration reference
 ```
 
 ## Circuit Breaker
@@ -219,21 +224,20 @@ api:
   api_url: "http://127.0.0.1:5000"
   timeout: 5
   max_concurrent: 10
-  retry_attempts: 3
+  # retries live under retry_logic, see the configuration reference
 
 # Data Configuration
-data:
-  metrics_file: "/var/log/lxc_metrics.json"
+data_file: "/var/log/lxc_metrics.json"
 
 # Logging Configuration
-logging:
-  log_level: "INFO"
-  log_file: "/var/log/lxc_autoscale_ml.log"
+log_level: "INFO"
+log_file: "/var/log/lxc_autoscale_ml.log"
 
 # ML Model Configuration
-isolation_forest:
-  contamination: 0.1
+model:
+  contamination: 0.05
   n_estimators: 100
+  max_samples: 64
   random_state: 42
 
 # Scaling Configuration
@@ -248,7 +252,8 @@ scaling:
   max_cpu_cores: 8
   min_ram_mb: 512
   max_ram_mb: 16384
-  min_confidence: 70  # 0 (the default) disables confidence gating
+  min_confidence: 0   # 0 disables confidence gating
+  dry_run: false      # Log decisions without applying them
 
 # Ignored Containers
 ignore_lxc: []
@@ -259,9 +264,13 @@ circuit_breaker:
   failure_threshold: 5
   timeout_seconds: 300
 
-# Sleep Configuration
-sleep_interval: 60
+# Cycle interval
+interval_seconds: 600
 ```
+
+The full, authoritative list is in the
+[configuration reference](/reference/configuration), which is generated from the
+files as shipped.
 
 ## Log Examples
 

--- a/docs/components/monitor.md
+++ b/docs/components/monitor.md
@@ -34,7 +34,7 @@ The Monitor component collects resource metrics from LXC containers and stores t
    ↓
 3. Append to Metrics File
    ↓
-4. Check File Size (limit to max_entries)
+4. Trim to max_metrics_entries
    ↓
 5. Sleep & Repeat
 ```
@@ -130,74 +130,76 @@ Automatic size limiting to 1000 entries (configurable).
 ### Configuration
 
 ```yaml
-metrics:
-  max_entries: 1000
+monitoring:
+  max_metrics_entries: 1000
 ```
 
-**Guidelines:**
+Each entry is one collection cycle covering every running container, so the
+file's size depends on how many containers you have as well as on this number.
+The model retrains from the whole file each cycle, so this also bounds how long
+training takes.
 
-| Deployment Size | Recommended `max_entries` |
-|-----------------|---------------------------|
-| Small (< 10 containers) | 500 |
-| Medium (10-50 containers) | 1000 (default) |
-| Large (50+ containers) | 1500 |
-
-### Impact
-
-| Metric | Before | After |
-|--------|--------|-------|
-| Max file size | Unlimited | ~2 MB |
-| Memory usage | Growing | Stable |
-| Model training time | Increasing | Constant |
+The oldest entries are dropped once the limit is reached, and the file is
+written through a temporary file and renamed into place, so an interrupted write
+cannot truncate it.
 
 ## Configuration Reference
 
 ```yaml
 # /etc/lxc_autoscale_ml/lxc_monitor.yaml
 
-# Metrics Configuration
-metrics:
-  output_file: "/var/log/lxc_metrics.json"
-  max_entries: 1000
-  collection_interval: 10  # Seconds
-
-# Logging Configuration
 logging:
-  log_level: "INFO"
   log_file: "/var/log/lxc_monitor.log"
+  log_max_bytes: 5242880   # rotate at 5 MB
+  log_backup_count: 7
+  log_level: "INFO"
 
-# Container Filter
-containers:
-  ignore_stopped: true
-  ignore_templates: true
-
-# Performance
-performance:
-  batch_size: 10
-  timeout: 5
+monitoring:
+  export_file: "/var/log/lxc_metrics.json"
+  check_interval: 60       # seconds between cycles
+  enable_swap: true
+  enable_network: true
+  enable_filesystem: true
+  parallel_processing: true
+  max_workers: 8
+  excluded_devices: ['loop', 'dm-']
+  retry_limit: 3
+  retry_delay: 2
+  max_metrics_entries: 1000
 ```
+
+Stopped containers are skipped because `pct list` is filtered on the status
+column; there is no separate setting for it. The full list of options is in the
+[configuration reference](/reference/configuration).
 
 ## Log Examples
 
 **Normal operation:**
 
 ```
-INFO - LXC Monitor started
-INFO - Found 12 running containers
-INFO - Collecting metrics from container 101...
-INFO - Collecting metrics from container 102...
-INFO - Collected metrics for 12 containers in 0.4s
-INFO - Metrics file size: 987 entries
-INFO - Sleeping for 10 seconds...
+INFO - Starting new metrics collection cycle.
+INFO - Collecting metrics for container: 101
+INFO - Collecting metrics for container: 102
+INFO - Metrics successfully exported to /var/log/lxc_metrics.json (987 entries)
+INFO - Waiting for 60 seconds before the next cycle.
 ```
 
 **Size limiting:**
 
 ```
-INFO - Collected metrics for 15 containers
-WARNING - Metrics file has 1023 entries (limit: 1000)
-INFO - Trimmed metrics file to 1000 entries (removed 23 oldest)
+INFO - Rotated metrics: removed 23 old entries, keeping last 1000
+INFO - Metrics successfully exported to /var/log/lxc_metrics.json (1000 entries)
 ```
+
+**A container that cannot be reached:**
+
+```
+WARNING - Attempt 1 failed for get_container_cpu_usage with error: ...
+ERROR - All 3 attempts failed for get_container_cpu_usage.
+ERROR - Failed to collect metrics for container 105: ...
+```
+
+One unreachable container does not cost the cycle; the rest are still written.
 
 **Errors:**
 
@@ -209,41 +211,40 @@ ERROR - Failed to parse metrics: Invalid JSON in lxc_metrics.json
 
 ## Performance Tuning
 
-### Small Deployments (< 20 containers)
+Three settings matter here: how often a cycle runs, how many containers are
+probed at once, and how much history is kept.
+
+### Few containers (under 20)
 
 ```yaml
-metrics:
-  collection_interval: 5   # More frequent
-  max_entries: 500
-
-performance:
-  batch_size: 10
-  timeout: 3
+monitoring:
+  check_interval: 30       # more frequent samples
+  max_workers: 8
+  max_metrics_entries: 500
 ```
 
-### Medium Deployments (20-60 containers)
+### Medium (20 to 60 containers)
 
 ```yaml
-metrics:
-  collection_interval: 10  # Default
-  max_entries: 1000
-
-performance:
-  batch_size: 10
-  timeout: 5
+monitoring:
+  check_interval: 60       # default
+  max_workers: 8
+  max_metrics_entries: 1000
 ```
 
-### Large Deployments (60+ containers)
+### Many containers (60 and above)
 
 ```yaml
-metrics:
-  collection_interval: 30  # Less frequent
-  max_entries: 1500
-
-performance:
-  batch_size: 20
-  timeout: 10
+monitoring:
+  check_interval: 120      # less frequent, each cycle costs more
+  max_workers: 16
+  max_metrics_entries: 1500
 ```
+
+`check_interval` should not be shorter than a cycle actually takes; the log line
+`Metrics successfully exported ...` tells you how long that is on your host.
+`max_workers` bounds how many `pct exec` calls run at once, so raising it costs
+host CPU during collection.
 
 ## Log Rotation
 

--- a/docs/components/monitor.md
+++ b/docs/components/monitor.md
@@ -248,7 +248,7 @@ host CPU during collection.
 
 ## Log Rotation
 
-Create `/etc/logrotate.d/lxc_monitor`:
+Create `/etc/logrotate.d/lxc-autoscale-api`:
 
 ```
 /var/log/lxc_monitor.log {

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -241,8 +241,8 @@ circuit_breaker:
 | `/etc/lxc_autoscale_ml/lxc_monitor.yaml` | Monitor configuration |
 | `/var/log/lxc_metrics.json` | Collected metrics |
 | `/var/log/lxc_autoscale_ml.log` | Model service log |
-| `/var/log/autoscaleapi.log` | API service log |
-| `/var/lock/lxc_autoscale_ml.lock` | Process lock file |
+| `/var/log/lxc_autoscale_api.log` | API service log |
+| `/run/lxc_autoscale_ml.lock` | Process lock file |
 
 ## Next Steps
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-LXC AutoScale ML uses a modular architecture with three main components that work together to provide intelligent autoscaling.
+LXC AutoScale ML is three separate systemd services that share nothing but a metrics file on disk.
 
 ## System Overview
 
@@ -202,7 +202,7 @@ Container 3 ─┼──▶ API (parallel) ──▶ All Responses
 ...          │
 Container 60─┘
                     │
-                    └─ Total: ~0.6s (10x faster)
+                    └─ issued concurrently, bounded by api.max_concurrent
 ```
 
 ## Circuit Breaker Pattern

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -225,39 +225,39 @@ scrape_configs:
 
 ### Useful PromQL Queries
 
-**Scaling rate per hour:**
+**Scaling rate per hour, by resource:**
 
 ```promql
-rate(lxc_scaling_actions_total[1h]) * 3600
+sum by (resource) (rate(lxc_autoscale_scaling_actions_total[1h])) * 3600
 ```
 
-**Scale up to scale down ratio:**
-
-```promql
-sum(lxc_scaling_actions_total{action="scale_up"})
-/
-sum(lxc_scaling_actions_total{action="scale_down"})
-```
+The `action` label is `set` for CPU and RAM and `increase` for storage; direction
+is not recorded, so scale-up and scale-down cannot be told apart here. The
+decision itself is in the model's log.
 
 **Average API response time:**
 
 ```promql
-rate(lxc_api_request_duration_seconds_sum[5m])
+rate(lxc_autoscale_api_request_duration_seconds_sum[5m])
 /
-rate(lxc_api_request_duration_seconds_count[5m])
+rate(lxc_autoscale_api_request_duration_seconds_count[5m])
 ```
 
-**Containers with high CPU usage:**
+**Containers whose scaling keeps failing:**
 
 ```promql
-lxc_container_cpu_usage_percent > 80
+sum by (container_id) (rate(lxc_autoscale_scaling_failures_total[15m])) > 0
 ```
 
-**Open circuit breakers:**
+**Total resources allocated across the fleet:**
 
 ```promql
-count(lxc_autoscale_container_cpu_cores)
+sum(lxc_autoscale_container_cpu_cores)
+sum(lxc_autoscale_container_memory_mb)
 ```
+
+Container *usage* is not exported here: it is collected by the monitor, which
+has no metrics endpoint. It is in `/var/log/lxc_metrics.json`.
 
 ## Alerting Examples
 
@@ -268,7 +268,7 @@ groups:
   - name: lxc_autoscale
     rules:
       - alert: HighScalingRate
-        expr: rate(lxc_scaling_actions_total[1h]) * 3600 > 10
+        expr: sum(rate(lxc_autoscale_scaling_actions_total[1h])) * 3600 > 10
         for: 5m
         labels:
           severity: warning
@@ -276,17 +276,17 @@ groups:
           summary: "High scaling activity detected"
           description: "More than 10 scaling actions per hour"
 
-      - alert: CircuitBreakerOpen
+      - alert: AutoScaleAPIDown
         expr: up{job="lxc-autoscale-api"} == 0
         for: 1m
         labels:
           severity: critical
         annotations:
-          summary: "Circuit breaker is open"
+          summary: "The AutoScale API is not responding"
           description: "API failures detected, circuit breaker is open"
 
       - alert: APIHighLatency
-        expr: rate(lxc_api_request_duration_seconds_sum[5m]) / rate(lxc_api_request_duration_seconds_count[5m]) > 1
+        expr: rate(lxc_autoscale_api_request_duration_seconds_sum[5m]) / rate(lxc_autoscale_api_request_duration_seconds_count[5m]) > 1
         for: 5m
         labels:
           severity: warning

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -65,18 +65,25 @@ Currently, resource limits (min/max CPU and RAM) are global settings. All contai
 Edit `/etc/lxc_autoscale_ml/lxc_autoscale_ml.yaml`:
 
 ```yaml
-sleep_interval: 120  # Seconds between scaling cycles
+interval_seconds: 120  # Seconds between scaling cycles
 ```
 
 ## Security
 
 ### Is the API secure?
 
-Yes. Version 2.0 includes:
-- API key authentication on all sensitive endpoints
-- Rate limiting (120 requests per minute)
-- Input validation on all parameters
-- Localhost bypass for internal services
+Only if you configure it that way. The defaults are permissive:
+
+- **Authentication is off** (`authentication.enabled: false`). Turn it on and
+  add keys before exposing the API anywhere.
+- **It binds to every interface** (`server.host: 0.0.0.0`). Set `127.0.0.1`
+  unless the model runs on a different host.
+- **It runs as root**, because `pct` requires it, and speaks plain HTTP. Put TLS
+  in front of it if it has to cross a network.
+
+What is on by default: per-IP rate limiting at 120 requests a minute with
+localhost exempt, and input validation on every parameter. Commands are handed
+to the kernel as argument lists and never go through a shell.
 
 ### Where should I store my API key?
 
@@ -108,15 +115,25 @@ server {
 
 ### How many containers can it handle?
 
-The system has been tested with up to 200 containers. The batch async API client maintains consistent performance regardless of container count.
+Configuration reads are issued concurrently, up to `api.max_concurrent` at a
+time, so the fetch stage does not grow linearly with container count. The
+scaling decisions themselves are made one container at a time. No specific
+upper bound has been measured.
 
 ### What is the performance overhead?
 
-Minimal. The ML model training typically uses less than 5% CPU during training cycles. Memory usage is bounded by the metrics file size limit (default: 1000 entries, approximately 2 MB).
+The model is retrained from the full metrics file on every cycle, so cost grows
+with history length; the file is capped at `max_metrics_entries` cycles (1000 by
+default), which bounds it. The monitor records its own CPU and memory use in the
+`summary` block of each cycle, so you can read the real figures for your host
+there rather than trusting an estimate.
 
-### Why is configuration fetching 10x faster in version 2.0?
+### How are container configurations fetched?
 
-Version 2.0 uses asynchronous batch API requests. Instead of fetching container configurations sequentially, all configurations are fetched concurrently. For 60 containers, this reduces fetch time from approximately 6 seconds to 0.6 seconds.
+Concurrently, rather than one after another, with at most `api.max_concurrent`
+requests in flight (10 by default) and exponential backoff on server errors.
+Each cycle logs how long the fetch took and how many succeeded, so the real
+figure for your host is in the log.
 
 ## Troubleshooting
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -142,7 +142,8 @@ Update the authentication section:
 ```yaml
 authentication:
   enabled: true
-  api_key: "your-secure-api-key-here"
+  api_keys:
+    - "your-secure-api-key-here"
 ```
 
 ::: tip

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -56,9 +56,9 @@ chmod +x /usr/local/bin/lxc_autoscale_ml/*/*.py
 
 ```bash
 mkdir -p /etc/lxc_autoscale_ml
-cp /usr/local/bin/lxc_autoscale_ml/api/lxc_autoscale_api.yaml /etc/lxc_autoscale_ml/
-cp /usr/local/bin/lxc_autoscale_ml/model/lxc_autoscale_ml.yaml /etc/lxc_autoscale_ml/
-cp /usr/local/bin/lxc_autoscale_ml/monitor/lxc_monitor.yaml /etc/lxc_autoscale_ml/
+cp /etc/lxc_autoscale_ml/lxc_autoscale_api.yaml /etc/lxc_autoscale_ml/
+cp /etc/lxc_autoscale_ml/lxc_autoscale_ml.yaml /etc/lxc_autoscale_ml/
+cp /etc/lxc_autoscale_ml/lxc_monitor.yaml /etc/lxc_autoscale_ml/
 ```
 
 ### Step 5: Install Systemd Services
@@ -72,7 +72,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /usr/local/bin/lxc_autoscale_ml/api/lxc_autoscale_api.py
+ExecStart=/usr/bin/python3 /usr/local/bin/lxc_autoscale_api/lxc_autoscale_api.py
 Restart=always
 RestartSec=10
 StandardOutput=journal
@@ -91,7 +91,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /usr/local/bin/lxc_autoscale_ml/monitor/lxc_monitor.py
+ExecStart=/usr/bin/python3 /usr/local/bin/lxc_monitor.py
 Restart=always
 RestartSec=10
 StandardOutput=journal
@@ -110,7 +110,7 @@ After=network.target lxc_autoscale_api.service lxc_monitor.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /usr/local/bin/lxc_autoscale_ml/model/lxc_autoscale_ml.py
+ExecStart=/usr/bin/python3 /usr/local/bin/lxc_autoscale_ml/lxc_autoscale_ml.py
 Restart=always
 RestartSec=10
 StandardOutput=journal
@@ -198,13 +198,22 @@ ls -la /var/log/lxc_metrics.json
 journalctl -u lxc_autoscale_ml -n 20
 ```
 
-## Log Rotation Setup
+## Log rotation
 
-Create `/etc/logrotate.d/lxc_autoscale`:
+The installer configures no logrotate stanza, and most logs do not need one:
+
+| Log | Rotated by |
+|-----|-----------|
+| `/var/log/lxc_autoscale_ml.log` | the model itself, at 10 MB, 5 kept |
+| `/var/log/lxc_monitor.log` | the monitor itself, per `logging.log_max_bytes` |
+| `/var/log/lxc_autoscale_api_access.log` | **nothing** |
+| `/var/log/lxc_autoscale_api_error.log` | **nothing** |
+
+Only gunicorn's two logs are unmanaged. If you keep them as files rather than
+sending them to the journal, create `/etc/logrotate.d/lxc-autoscale-api`:
 
 ```
-/var/log/lxc_autoscale_ml.log
-/var/log/autoscaleapi*.log {
+/var/log/lxc_autoscale_api_*.log {
     daily
     missingok
     rotate 7
@@ -215,10 +224,17 @@ Create `/etc/logrotate.d/lxc_autoscale`:
     sharedscripts
     postrotate
         systemctl reload lxc_autoscale_api > /dev/null 2>&1 || true
-        systemctl reload lxc_autoscale_ml > /dev/null 2>&1 || true
     endscript
 }
 ```
+
+`lxc_autoscale_api` is the only unit with an `ExecReload`. Do not add the model
+or the monitor to a `postrotate` reload: they have none, and rotating their
+files externally fights the rotation they already do.
+
+Alternatively set `gunicorn.access_log_file` and `gunicorn.error_log_file` to
+`"-"` in `lxc_autoscale_api.yaml`, which sends both to the journal and removes
+the need for logrotate entirely.
 
 ## Troubleshooting Installation
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -143,7 +143,8 @@ Edit `/etc/lxc_autoscale_ml/lxc_autoscale_api.yaml`:
 ```yaml
 authentication:
   enabled: true
-  api_key: "your-generated-key-here"
+  api_keys:
+    - "your-generated-key-here"
 ```
 
 Restart the API service:

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,6 +1,9 @@
 # What is LXC AutoScale ML?
 
-LXC AutoScale ML is a resource management daemon for Proxmox environments. It monitors LXC container resource usage and automatically adjusts CPU and memory allocations with zero downtime, using machine learning to predict resource demands.
+LXC AutoScale ML adjusts the CPU and memory allocated to Proxmox LXC
+containers. It collects per-container metrics, trains an anomaly detection model
+on each container's own history, and applies changes by running `pct` on the
+host. Resizing CPU and memory with `pct set` does not restart the container.
 
 ## Key Features
 
@@ -21,15 +24,26 @@ Resources scale gradually to avoid instability:
 
 This prevents the system from jumping between minimum and maximum allocations.
 
-### High-Performance Architecture
+### Concurrent configuration fetching
 
-The batch async API client fetches container configurations concurrently, providing **10x faster** performance compared to sequential requests. A deployment with 60 containers completes configuration fetching in approximately 0.6 seconds.
+Before deciding, the model reads each container's current allocation from the
+API. Those reads are issued concurrently, up to `api.max_concurrent` at a time
+(10 by default), so a cycle does not grow linearly with the number of
+containers. How much that saves depends on how quickly the API answers, which
+depends on how quickly `pct config` returns on your host.
 
-### Enterprise Security
+### Security
 
-- **API Key Authentication**: All sensitive endpoints require authentication
-- **Rate Limiting**: 120 requests per minute with automatic localhost bypass
-- **Input Validation**: Comprehensive parameter validation prevents injection attacks
+- **API key authentication**, off by default. When enabled, every endpoint
+  except `/health/check` and `/metrics` requires a key, compared in constant
+  time.
+- **Per-IP rate limiting**, 120 requests per minute by default, with localhost
+  exempt so the model is not throttled.
+- **Input validation** on every parameter. Commands are handed to the kernel as
+  argument lists and never go through a shell.
+
+The API runs as root, because `pct` requires it, and binds to every interface by
+default. See [Configuration](/reference/configuration) before exposing it.
 
 ### Fault Tolerance
 

--- a/docs/guide/requirements.md
+++ b/docs/guide/requirements.md
@@ -79,8 +79,16 @@ These packages are installed automatically by the installation script:
 |------|---------|--------|
 | 5000 | API | Localhost by default |
 
-::: tip
-The API listens on all interfaces but is protected by API key authentication. For additional security, restrict access using firewall rules.
+::: danger The API ships unauthenticated
+`server.host` defaults to `0.0.0.0` and `authentication.enabled` defaults to
+`false`, so out of the box anything that can route to port 5000 can resize,
+snapshot, clone and destroy containers. The service runs as root, because it
+executes `pct`.
+
+On the standard single-node layout, set `server.host: 127.0.0.1` — the model
+runs beside the API and does not need it exposed. If it must be reachable from
+another host, enable `authentication`, set a matching `api.api_key` in the model
+configuration, put TLS in front of it, and restrict access with firewall rules.
 :::
 
 ### Outbound Connections
@@ -95,7 +103,7 @@ The installation script requires internet access to download packages and source
 |-----------|---------|-------------|
 | `/etc/lxc_autoscale_ml/` | Configuration files | root:root 755 |
 | `/var/log/` | Log files | root:root 755 |
-| `/var/lock/` | Lock files | root:root 755 |
+| `/run/` | Lock file (tmpfs, cleared on boot) | root:root 755 |
 | `/usr/local/bin/lxc_autoscale_ml/` | Application code | root:root 755 |
 
 ### Disk Space for Logs
@@ -104,7 +112,7 @@ The installation script requires internet access to download packages and source
 |------|-------------|-------|
 | `lxc_metrics.json` | 2 MB max | Limited to 1000 entries |
 | `lxc_autoscale_ml.log` | Varies | Use logrotate |
-| `autoscaleapi.log` | Varies | Use logrotate |
+| `lxc_autoscale_api_access.log` | Varies | Use logrotate |
 
 ## Container Requirements
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -240,7 +240,7 @@ grep -A2 "authentication" /etc/lxc_autoscale_ml/lxc_autoscale_api.yaml
 curl -H "X-API-Key: your-key" http://localhost:5000/routes
 
 # Alternative (query parameter)
-curl "http://localhost:5000/routes?api_key=your-key"
+curl -H "X-API-Key: your-key" http://localhost:5000/routes
 ```
 
 ### Lock File Issues
@@ -251,14 +251,14 @@ Version 2.0 includes automatic stale lock cleanup. If the issue persists:
 
 ```bash
 # Check if process is running
-cat /var/lock/lxc_autoscale_ml.lock
-ps -p $(cat /var/lock/lxc_autoscale_ml.lock)
+cat /run/lxc_autoscale_ml.lock
+ps -p $(cat /run/lxc_autoscale_ml.lock)
 
 # If process not running, service auto-cleans
 systemctl restart lxc_autoscale_ml
 
 # Manual cleanup (if needed)
-rm /var/lock/lxc_autoscale_ml.lock
+rm /run/lxc_autoscale_ml.lock
 systemctl start lxc_autoscale_ml
 ```
 

--- a/docs/guide/uninstallation.md
+++ b/docs/guide/uninstallation.md
@@ -49,19 +49,19 @@ rm -rf /etc/lxc_autoscale_ml
 ```bash
 rm /var/log/lxc_metrics.json
 rm /var/log/lxc_autoscale_ml.log
-rm /var/log/autoscaleapi*.log
+rm /var/log/lxc_autoscale_api_*.log
 ```
 
 ### Step 6: Remove Lock File (If Exists)
 
 ```bash
-rm -f /var/lock/lxc_autoscale_ml.lock
+rm -f /run/lxc_autoscale_ml.lock
 ```
 
 ### Step 7: Remove Log Rotation Configuration (Optional)
 
 ```bash
-rm /etc/logrotate.d/lxc_autoscale
+rm /etc/logrotate.d/lxc-autoscale-api
 ```
 
 ## Verify Uninstallation

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -42,7 +42,8 @@ Add new settings to `/etc/lxc_autoscale_ml/lxc_autoscale_api.yaml`:
 ```yaml
 authentication:
   enabled: true
-  api_key: "your-secret-key-here"  # Generate with: openssl rand -hex 32
+  api_keys:
+    - "your-secret-key-here"  # Generate with: openssl rand -hex 32
 
 rate_limiting:
   enabled: true
@@ -68,8 +69,8 @@ circuit_breaker:              # NEW section
 Add new settings to `/etc/lxc_autoscale_ml/lxc_monitor.yaml`:
 
 ```yaml
-metrics:
-  max_entries: 1000           # NEW: Automatic size limiting
+monitoring:
+  max_metrics_entries: 1000   # NEW: bounds the metrics file
 ```
 
 ### Step 6: Start Services

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -232,7 +232,7 @@ systemctl restart lxc_monitor
 If the service fails to start due to a stale lock:
 
 ```bash
-rm /var/lock/lxc_autoscale_ml.lock
+rm /run/lxc_autoscale_ml.lock
 systemctl start lxc_autoscale_ml
 ```
 

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -169,10 +169,10 @@ Example metrics:
 
 ```
 # Scaling actions
-lxc_scaling_actions_total{container_id="104",action="scale_up",resource="cpu"} 15
+lxc_autoscale_scaling_actions_total{container_id="104",resource="cpu",action="set"} 15
 
 # API requests
-lxc_api_requests_total{endpoint="/scale/cores",method="POST",status="200"} 42
+lxc_autoscale_api_requests_total{method="POST",endpoint="/scale/cores",status="200"} 42
 
 # Container resources
 lxc_container_cpu_cores{container_id="104"} 4

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: LXC AutoScale ML
-  text: ML-Powered Autoscaling for Proxmox
-  tagline: Automatically adjust LXC container resources based on real-time usage and machine learning predictions
+  text: Automatic resource scaling for Proxmox LXC containers
+  tagline: Collects per-container metrics, learns what normal looks like, and adjusts CPU and memory through the Proxmox CLI
   image:
     src: /lxc_autoscale_ml.png
     alt: LXC AutoScale ML
@@ -17,49 +17,51 @@ hero:
       link: https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml
 
 features:
-  - icon: 🤖
-    title: ML-Driven Autoscaling
-    details: Uses IsolationForest anomaly detection to predict resource demands and make intelligent scaling decisions based on historical patterns.
-  - icon: ⚡
-    title: High Performance
-    details: Batch async API client provides 10x faster configuration fetching. Handles 60+ containers with minimal latency.
-  - icon: 🔒
-    title: Enterprise Security
-    details: API key authentication, rate limiting with localhost bypass, and comprehensive input validation on all endpoints.
-  - icon: 🛡️
-    title: Fault Tolerant
-    details: Circuit breaker pattern prevents cascading failures. Automatic recovery from crashes with stale lock cleanup.
-  - icon: 📊
-    title: Prometheus Metrics
-    details: Native metrics export for comprehensive observability. Track scaling actions, API requests, and container resources.
-  - icon: 🔧
-    title: Incremental Scaling
-    details: Gradual resource adjustment prevents instability. Scale by configurable step sizes instead of jumping to extremes.
+  - title: Anomaly-based decisions
+    details: An IsolationForest model is trained on each container's own history, so what counts as unusual is learned per container rather than fixed in advance.
+  - title: Threshold scaling with limits
+    details: Resources move by a configured step at a time, between a floor and a ceiling you set, rather than jumping to either extreme.
+  - title: Concurrent config fetching
+    details: Container configurations are read in parallel with a bounded concurrency limit, so a cycle does not grow linearly with the number of containers.
+  - title: Optional API authentication
+    details: API key authentication, per-IP rate limiting and input validation on every endpoint. Authentication is off by default and has to be enabled.
+  - title: Circuit breaker
+    details: After repeated failures the model stops calling the API for that container for a configurable period, instead of retrying on every cycle.
+  - title: Prometheus metrics
+    details: The API exports request, scaling and container allocation metrics at /metrics. Only metrics something actually populates are declared.
 ---
 
-## Quick Start
+## Quick start
 
-Install LXC AutoScale ML on your Proxmox host:
+Install on your Proxmox host:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/fabriziosalmi/proxmox-lxc-autoscale-ml/main/install.sh | bash
 ```
 
-Check service status:
+Check the three services:
 
 ```bash
 systemctl status lxc_autoscale_api lxc_monitor lxc_autoscale_ml
 ```
 
-## System Requirements
+Before letting it act on anything, set `dry_run: true` in
+`/etc/lxc_autoscale_ml/lxc_autoscale_ml.yaml` and read the log for a few cycles.
+It will report the decisions it would have taken without calling the API.
+
+## Requirements
 
 | Requirement | Version |
 |-------------|---------|
-| Proxmox VE | 6.x or higher (tested on 8.2.4) |
-| Python | 3.x |
-| Operating System | Linux (Debian-based) |
+| Proxmox VE | 8.x (Debian 12). Developed and tested there. |
+| Python | 3.10 to 3.12 |
+| Operating system | Debian-based Linux |
 
-## How It Works
+Proxmox VE 9 ships Python 3.13, which the pinned `numpy`, `pandas` and
+`scikit-learn` do not yet support. The API and the monitor run there; the model
+does not.
+
+## How it works
 
 ```
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
@@ -73,12 +75,20 @@ systemctl status lxc_autoscale_api lxc_monitor lxc_autoscale_ml
   network stats      predict needs       containers
 ```
 
-1. **Monitor** collects resource metrics from all running LXC containers
-2. **Model** trains an IsolationForest model and predicts scaling needs
-3. **API** executes scaling actions on the Proxmox host
+1. **Monitor** reads CPU, memory, I/O, network and filesystem figures from every
+   running container and appends them to a JSON file.
+2. **Model** trains an IsolationForest on that history, compares the latest
+   sample against configured thresholds, and decides whether to scale.
+3. **API** carries the decision out by running `pct` on the host.
+
+The three run as separate systemd services and only share the metrics file.
+
+## Status
+
+See the [changelog](https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml/blob/main/CHANGELOG.md).
+v1.3.0 fixed three defects that each broke the scaling loop end to end, so
+versions before it did not autoscale. If you are running one, upgrade.
 
 ## License
 
-LXC AutoScale ML is released under the [MIT License](https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml/blob/main/LICENSE).
-
-Enjoy and contribute :) 
+Released under the [MIT License](https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml/blob/main/LICENSE).

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -4,24 +4,33 @@ Complete reference for all LXC AutoScale ML API endpoints.
 
 ## Authentication
 
-All endpoints except `/health/check` and `/metrics` require authentication.
+::: warning Disabled in the shipped configuration
+`authentication.enabled` defaults to **false**, and `server.host` defaults to
+`0.0.0.0`. Out of the box this API is reachable on every interface with no
+credential, and it runs as root. See
+[Configuration](/reference/configuration) before exposing it.
+:::
 
-**Header authentication (recommended):**
+When enabled, every endpoint except `/`, `/health/check` and `/metrics`
+requires a key, supplied in the `X-API-Key` header:
 
 ```bash
-curl -H "X-API-Key: your-key" http://localhost:5000/endpoint
+curl -H "X-API-Key: your-key" http://localhost:5000/resource/lxc/status?lxc_id=104
 ```
 
-**Query parameter authentication:**
+The `?api_key=` query-parameter form was removed: gunicorn's access log records
+the request line, so the key ended up in a log file, in shell history, and in
+any proxy log in front of the API.
 
-```bash
-curl "http://localhost:5000/endpoint?api_key=your-key"
-```
+If you enable authentication, set `api.api_key` in the **model** configuration
+to a matching value. The model has no other way to authenticate, and without it
+autoscaling stops with a 401 on every call.
 
 ## Endpoints Summary
 
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
+| `/` | GET | No | Self-documenting index |
 | `/health/check` | GET | No | API health status |
 | `/metrics` | GET | No | Prometheus metrics |
 | `/routes` | GET | Yes | List all routes |
@@ -54,8 +63,10 @@ working without changes:
 | `new_lxc_id` | `new_vm_id` |
 | `new_lxc_name` | `new_vm_name`, `hostname` |
 
-Every endpoint accepts its parameters from either a JSON body or the query
-string, whichever is more convenient.
+**GET** endpoints take their parameters from the query string. **POST** and
+**DELETE** endpoints require a JSON body: accepting the query string on
+mutating methods made them drivable by a cross-origin HTML form, which is a
+CORS simple request and needs no preflight.
 
 ---
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -95,9 +95,9 @@ curl http://localhost:5000/metrics
 **Response (200 OK):**
 
 ```
-# HELP lxc_scaling_actions_total Total scaling actions
-# TYPE lxc_scaling_actions_total counter
-lxc_scaling_actions_total{container_id="104",action="scale_up",resource="cpu"} 15
+# HELP lxc_autoscale_scaling_actions_total Total scaling actions performed
+# TYPE lxc_autoscale_scaling_actions_total counter
+lxc_autoscale_scaling_actions_total{container_id="104",resource="cpu",action="set"} 15
 ...
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -140,11 +140,21 @@ gunicorn:
   # Time to wait before forcefully killing workers during a graceful restart.
   graceful_timeout_seconds: 30  
   
-  # Number of requests a worker will handle before being restarted. Helps to prevent memory leaks.
-  max_requests: 500  
-  
-  # Adds a random jitter to `max_requests` to avoid all workers restarting at the same time.
-  max_requests_jitter: 50
+  # Requests a worker handles before being recycled. 0 disables it, which is
+  # the default and is deliberate: the rate-limiter window and the Prometheus
+  # counters live in worker memory, so recycling silently resets both -- and a
+  # client's own rejected requests drove the recycle that cleared its window.
+  # The limiter evicts idle clients itself, so recycling is not needed to bound
+  # memory.
+  max_requests: 0
+
+  # Random spread on max_requests. Irrelevant while max_requests is 0.
+  max_requests_jitter: 0
+
+  # Access log format. Deliberately omits the query string: the default format
+  # logs the whole request line, and this log is not a place for anything a
+  # caller passes as a parameter.
+  access_log_format: '%(h)s "%(m)s %(U)s %(H)s" %(s)s %(b)s %(D)sus'
 ```
 
 ## Model configuration
@@ -219,6 +229,11 @@ api:
   cores_endpoint: "/scale/cores"  # Endpoint for scaling CPU cores
   ram_endpoint: "/scale/ram"  # Endpoint for scaling RAM
   timeout_seconds: 5  # Per-request timeout when talking to the API
+
+  # API key, sent as X-API-Key. REQUIRED if the API has
+  # authentication.enabled: true -- without it every request is rejected with
+  # 401 and autoscaling stops. Must match one of the API's authentication.api_keys.
+  # api_key: "your-secret-api-key-here"
   max_concurrent: 10  # Maximum parallel config fetches
 
 # Retry Logic for API Calls
@@ -236,11 +251,12 @@ circuit_breaker:
   timeout_seconds: 300  # How long the circuit stays open before retrying
 
 # Ignored Containers
-ignore_lxc:
-  # List container IDs to exclude from autoscaling
-  # Example: ["100", "999"] 
-  # Note: 101 and 102 are common first container IDs - don't ignore them by default!
-  []  # Empty list = scale all containers
+# Container IDs to exclude from autoscaling. An empty list scales everything.
+# IDs are matched as strings, so [101, 102] and ["101", "102"] both work.
+# Example: ignore_lxc: ["100", "999"]
+# Note: 101 and 102 are commonly the first containers on a host, so do not
+# ignore them out of habit.
+ignore_lxc: []
 ```
 
 ## Monitor configuration
@@ -292,6 +308,12 @@ monitoring:
   
   # Delay between retry attempts in seconds.
   retry_delay: 2
+
+  # Timeout in seconds for each pct invocation. Without a bound, one wedged
+  # container froze the whole collection cycle indefinitely: the process
+  # neither exited nor errored, so systemd never restarted it and the metrics
+  # file was never updated again.
+  command_timeout: 30
   
   # Maximum number of metrics entries to keep in the export file (prevents unbounded growth).
   max_metrics_entries: 1000  # Keeps last 1000 data points (~16 hours at 60s intervals)
@@ -325,8 +347,8 @@ monitoring:
 | `gunicorn.threads` | integer | `8` | Threads per worker |
 | `gunicorn.timeout_seconds` | integer | `120` | Worker timeout |
 | `gunicorn.graceful_timeout_seconds` | integer | `30` | Grace period on restart |
-| `gunicorn.max_requests` | integer | `500` | Requests before a worker is recycled |
-| `gunicorn.max_requests_jitter` | integer | `50` | Random spread on the above |
+| `gunicorn.max_requests` | integer | `0` | Requests before a worker is recycled. 0 disables it, deliberately: recycling resets the rate-limiter window and the Prometheus counters, and a client's own rejected requests drove the recycle that cleared its window. |
+| `gunicorn.max_requests_jitter` | integer | `0` | Random spread on the above. Irrelevant while recycling is off. |
 | `gunicorn.preload_app` | boolean | `true` | Load the app before forking |
 | `gunicorn.log_level` | string | `info` | Gunicorn's own log level |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,312 +1,495 @@
 # Configuration Reference
 
-This page documents all configuration options for LXC AutoScale ML.
+Every option below exists in the shipped configuration files and is read by the
+code. The YAML blocks are the files as installed, so what you see here is what
+lands in `/etc/lxc_autoscale_ml/`.
 
-## Configuration Files
+::: tip Keeping this honest
+`tests/test_config_contract.py` fails if a configuration file grows a key no
+code reads, or if this page documents a key no configuration file has. Eleven
+such keys existed before v1.3.0 -- including `dry_run`, which meant anyone
+rehearsing a change with it was scaling for real.
+:::
 
-| Component | Path |
-|-----------|------|
-| API | `/etc/lxc_autoscale_ml/lxc_autoscale_api.yaml` |
-| Model | `/etc/lxc_autoscale_ml/lxc_autoscale_ml.yaml` |
-| Monitor | `/etc/lxc_autoscale_ml/lxc_monitor.yaml` |
+## Configuration files
 
-## API Configuration
+| Component | Path | Service |
+|-----------|------|---------|
+| API | `/etc/lxc_autoscale_ml/lxc_autoscale_api.yaml` | `lxc_autoscale_api` |
+| Model | `/etc/lxc_autoscale_ml/lxc_autoscale_ml.yaml` | `lxc_autoscale_ml` |
+| Monitor | `/etc/lxc_autoscale_ml/lxc_monitor.yaml` | `lxc_monitor` |
 
-### Complete Reference
+On upgrade the installer never overwrites an existing file; the shipped defaults
+are written alongside it as `<name>.yaml.new`.
+
+
+## API configuration
+
+Read by the API service, which executes `pct` commands as root.
 
 ```yaml
 # /etc/lxc_autoscale_ml/lxc_autoscale_api.yaml
-
-# Server Configuration
+# HTTP listener
 server:
-  host: "0.0.0.0"          # Bind address
-  port: 5000               # Listen port
+  # Address the API binds to. 0.0.0.0 keeps the historical behaviour and exposes
+  # the API on every interface. The API runs as root and executes pct commands,
+  # so bind it to 127.0.0.1 unless the ML service runs on a different host --
+  # and enable authentication below if it does.
+  host: "0.0.0.0"
 
-# LXC
+  # TCP port the API listens on.
+  port: 5000
+
 lxc:
-  node: "proxmox"          # Proxmox node name or IP
-  default_storage: "local-lvm"
-  timeout_seconds: 10      # Timeout for pct/pvesh commands
+  # Name or IP address of the Proxmox node where LXC containers are managed.
+  node: "proxmox"  # Replace with your Proxmox node name or IP. Note: if node name or hostname won't work use IP address instead, should work as expected.
+  
+  # Default storage location for LXC containers.
+  default_storage: "local-lvm"  # Default storage location
+  
+  # Timeout for operations in seconds.
+  timeout_seconds: 10
 
-# Authentication
-authentication:
-  enabled: false           # Enable API key authentication
-  api_keys:                # One or more valid keys (change these!)
-    - "your-key"
-
-# Rate Limiting
 rate_limiting:
-  enabled: true            # Enable rate limiting
-  max_requests_per_minute: 120  # Max requests per IP
-  time_window_seconds: 60  # Sliding window duration
+  # Enable or disable rate limiting globally
+  enabled: true
+  
+  # Maximum number of requests allowed per client IP
+  # Note: localhost (127.0.0.1) is always exempt for internal ML service
+  max_requests_per_minute: 120  # Increased from 60 to handle multiple containers
+  
+  # Time window for rate limiting in seconds (default 60)
+  time_window_seconds: 60
 
-# Logging
+# Authentication Configuration
+authentication:
+  # Enable API key authentication for all endpoints (except /health/check and /metrics)
+  enabled: false  # Set to true in production
+  
+  # List of valid API keys - CHANGE THESE IN PRODUCTION!
+  # Generate secure keys with: python3 -c "import os; print(os.urandom(32).hex())"
+  api_keys: []
+    # Example:
+    # - "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6"
+
 logging:
-  level: "INFO"            # DEBUG, INFO, WARNING, ERROR, CRITICAL
-  log_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-  # log_file: "/var/log/lxc_autoscale_api.log"  # Unset: log to stdout only
-  rotate: true             # Rotate log_file when it grows past max_log_size_mb
+  # Logging level that controls the verbosity of logs. Options include "DEBUG", "INFO", "WARNING", "ERROR", and "CRITICAL".
+  level: "INFO"
+  
+  # Whether to enable log rotation to manage log file size.
+  rotate: true
+  
+  # Maximum size of the log file in megabytes before it is rotated.
   max_log_size_mb: 100
+  
+  # Number of backup log files to keep. Older files are deleted when new ones are created.
   backup_count: 5
+  
+  # Format for log messages. Uses Python's logging format string.
+  log_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"  # Log format
 
-# Error Handling
+  # Optional log file. When unset the API logs to stdout only, which systemd
+  # captures in the journal (journalctl -u lxc_autoscale_api). When set, the
+  # file is rotated using max_log_size_mb and backup_count above.
+  # log_file: "/var/log/lxc_autoscale_api.log"
+
+  # HTTP access and error logs are gunicorn's; see the gunicorn section below.
+
 error_handling:
-  show_stack_traces: false # Include exception detail in API error responses
+  # Whether to display stack traces in error messages.
+  show_stack_traces: false
+  
+  # Whether to log errors to the error log file.
   log_errors: true
+  
+  # Whether to send notifications for critical errors.
+  notify_on_critical_errors: false
+  
+  # List of email addresses to notify in case of critical errors.
+  notification_recipients:
+    # Email address to receive notifications.
+    - "your-email@inbox.com"
+
+gunicorn:
+  # Number of worker *processes*. Keep this at 1.
+  # Rate limiting and Prometheus metrics are held in process memory, so N
+  # workers means N independent rate limiters (N times the configured limit)
+  # and /metrics reporting only the worker that answered. Use threads below
+  # for concurrency instead: the work here is waiting on pct, not CPU.
+  workers: 1
+
+  # Number of threads per worker.
+  threads: 8 
+  
+  # Timeout for worker processes in seconds. Defines how long a worker can handle a request before being killed.
+  timeout_seconds: 120 
+  
+  # Log level for Gunicorn, which affects the verbosity of logs.
+  log_level: "info" 
+  
+  # Path to the file where Gunicorn access logs are written ("-" for stdout,
+  # which systemd captures in the journal).
+  access_log_file: "/var/log/lxc_autoscale_api_access.log"  
+  
+  # Path to the file where Gunicorn error logs are written.
+  error_log_file: "/var/log/lxc_autoscale_api_error.log"
+  
+  # Whether to preload the application before forking worker processes. Reduces startup time but uses more memory.
+  preload_app: true 
+  
+  # Time to wait before forcefully killing workers during a graceful restart.
+  graceful_timeout_seconds: 30  
+  
+  # Number of requests a worker will handle before being restarted. Helps to prevent memory leaks.
+  max_requests: 500  
+  
+  # Adds a random jitter to `max_requests` to avoid all workers restarting at the same time.
+  max_requests_jitter: 50
 ```
 
-### API Options
+## Model configuration
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `server.host` | string | `0.0.0.0` | Network interface to bind |
-| `server.port` | integer | `5000` | TCP port number |
-| `lxc.node` | string | - | Proxmox node name or IP |
-| `lxc.timeout_seconds` | integer | `30` | Timeout for `pct`/`pvesh` commands |
-| `authentication.enabled` | boolean | `false` | Require API key |
-| `authentication.api_keys` | list | `[]` | Accepted API keys |
-| `rate_limiting.enabled` | boolean | `true` | Enable rate limits |
-| `rate_limiting.max_requests_per_minute` | integer | `120` | Request limit per IP |
-| `rate_limiting.time_window_seconds` | integer | `60` | Window duration |
-| `logging.level` | string | `INFO` | Minimum log level |
-| `logging.log_file` | string | - | Optional log file; stdout only when unset |
-| `logging.rotate` | boolean | `true` | Rotate `log_file` |
-| `logging.max_log_size_mb` | integer | `100` | Rotation threshold |
-| `logging.backup_count` | integer | `5` | Rotated files to keep |
-| `error_handling.show_stack_traces` | boolean | `false` | Expose exception detail in responses |
-
-::: warning Binding and authentication
-The API runs as root and executes `pct` commands. With the default
-`server.host: 0.0.0.0` it is reachable from every interface. On the standard
-single-node layout, where the ML service runs beside it, bind to `127.0.0.1`.
-If it must be reachable remotely, enable `authentication` and put it behind TLS.
-:::
-
-## Model Configuration
-
-### Complete Reference
+Read by the scaling loop.
 
 ```yaml
 # /etc/lxc_autoscale_ml/lxc_autoscale_ml.yaml
-
-# API Configuration
-api:
-  api_url: "http://127.0.0.1:5000"  # API base URL
-  cores_endpoint: "/scale/cores"
-  ram_endpoint: "/scale/ram"
-  timeout_seconds: 5       # Request timeout (seconds)
-  max_concurrent: 10       # Max parallel config fetches
-
-# Retry Logic for API Calls
-retry_logic:
-  max_retries: 3           # Retry failed requests
-  retry_delay: 2           # Delay between retries (seconds)
-
-# Data Configuration
-data:
-  metrics_file: "/var/log/lxc_metrics.json"
+# =============================================================
+#                      LXC AutoScale ML
+#           Automated Container Scaling Configuration
+# -------------------------------------------------------------
+# This configuration file controls the behavior of the LXC 
+# AutoScale ML script. It includes settings for logging, 
+# model training, spike detection, scaling actions, API 
+# interactions, and more.
+#
+# The script is designed to automatically scale LXC containers 
+# based on real-time metrics, such as CPU usage, memory usage, 
+# and other system indicators. The scaling decisions are made 
+# using machine learning models, which can detect anomalies 
+# and trends in the data.
+#
+# Author: Fabrizio Salmi - fabrizio.salmi@gmail.com
+# Date: August 20, 2024
+# =============================================================
 
 # Logging Configuration
-logging:
-  log_level: "INFO"        # DEBUG, INFO, WARNING, ERROR
-  log_file: "/var/log/lxc_autoscale_ml.log"
+log_file: "/var/log/lxc_autoscale_ml.log"  # Path to the log file
+log_level: "DEBUG"  # Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 
-# IsolationForest Configuration
-isolation_forest:
-  contamination: 0.1       # Expected anomaly fraction
-  n_estimators: 100        # Number of trees
-  random_state: 42         # Random seed
-  max_samples: "auto"      # Samples per tree
+# Lock File Configuration
+lock_file: "/run/lxc_autoscale_ml.lock"  # Path to the lock file to prevent multiple instances
+
+# Data File Configuration
+data_file: "/var/log/lxc_metrics.json"  # Path to the metrics file containing container data produced by LXC AutoScale API
+
+# Model Configuration
+model:
+  contamination: 0.05  # Contamination level for IsolationForest (fraction of outliers)
+  n_estimators: 100  # Number of trees in IsolationForest
+  max_samples: 64  # Number of samples to draw for training each tree
+  random_state: 42  # Random seed for reproducibility
+
+# Spike Detection Configuration
+spike_detection:
+  spike_threshold: 2  # Number of standard deviations for spike detection
+  rolling_window: 5  # Window size for rolling mean and standard deviation
 
 # Scaling Configuration
 scaling:
-  # CPU Thresholds (percentage)
-  cpu_scale_up_threshold: 70
-  cpu_scale_down_threshold: 30
-  cpu_scale_step: 1        # Cores to add/remove
+  max_cpu_cores: 4  # Maximum number of CPU cores to maintain per container
+  max_ram_mb: 8192  # Maximum RAM to maintain per container in MB
+  min_cpu_cores: 2  # Minimum number of CPU cores to maintain per container
+  min_ram_mb: 1024  # Minimum RAM to maintain per container in MB
+  cpu_scale_step: 1  # Number of CPU cores to add/remove per scaling action
+  ram_scale_step_mb: 512  # Amount of RAM in MB to add/remove per scaling action
+  cpu_scale_up_threshold: 75  # CPU usage percentage to trigger scale-up
+  cpu_scale_down_threshold: 30  # CPU usage percentage to trigger scale-down
+  ram_scale_up_threshold: 75  # RAM usage percentage to trigger scale-up
+  ram_scale_down_threshold: 30  # RAM usage percentage to trigger scale-down
+  # Minimum confidence (0-100) required before a scaling action is applied.
+  # 0 disables the check. Confidence is the distance of the prediction from the
+  # model's decision boundary.
+  min_confidence: 0
 
-  # RAM Thresholds (percentage)
-  ram_scale_up_threshold: 80
-  ram_scale_down_threshold: 40
-  ram_scale_step_mb: 512   # MB to add/remove
+  dry_run: false  # If true, log scaling decisions without calling the API
 
-  # Resource Limits
-  min_cpu_cores: 1
-  max_cpu_cores: 8
-  min_ram_mb: 512
-  max_ram_mb: 16384
+# API Configuration
+api:
+  api_url: "http://127.0.0.1:5000"  # Base URL for the API used for scaling actions
+  cores_endpoint: "/scale/cores"  # Endpoint for scaling CPU cores
+  ram_endpoint: "/scale/ram"  # Endpoint for scaling RAM
+  timeout_seconds: 5  # Per-request timeout when talking to the API
+  max_concurrent: 10  # Maximum parallel config fetches
 
-  # Confidence
-  min_confidence: 70       # Minimum confidence to scale
+# Retry Logic for API Calls
+retry_logic:
+  max_retries: 3  # Maximum number of retries for API calls
+  retry_delay: 2  # Delay between retries in seconds
 
-  # Testing
-  dry_run: false           # Log decisions without executing
+# Interval Configuration
+interval_seconds: 600  # Time interval between consecutive script runs in seconds
+
+# Circuit Breaker for API calls
+circuit_breaker:
+  enabled: true  # Stop calling the API for a container after repeated failures
+  failure_threshold: 3  # Consecutive failures before the circuit opens
+  timeout_seconds: 300  # How long the circuit stays open before retrying
 
 # Ignored Containers
-ignore_lxc: []             # List of container IDs to skip
-
-# Circuit Breaker
-circuit_breaker:
-  enabled: true
-  failure_threshold: 5     # Failures before opening
-  timeout_seconds: 300     # Time before reset
-
-# Sleep Configuration
-sleep_interval: 60         # Seconds between cycles
+ignore_lxc:
+  # List container IDs to exclude from autoscaling
+  # Example: ["100", "999"] 
+  # Note: 101 and 102 are common first container IDs - don't ignore them by default!
+  []  # Empty list = scale all containers
 ```
 
-### Model Options
+## Monitor configuration
 
-#### API Settings
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `api.api_url` | string | `http://127.0.0.1:5000` | API base URL |
-| `api.cores_endpoint` | string | `/scale/cores` | CPU scaling endpoint |
-| `api.ram_endpoint` | string | `/scale/ram` | RAM scaling endpoint |
-| `api.timeout_seconds` | integer | `5` | Request timeout in seconds (`timeout` also accepted) |
-| `api.max_concurrent` | integer | `10` | Maximum parallel config fetches |
-| `retry_logic.max_retries` | integer | `3` | Retry count for failures |
-| `retry_logic.retry_delay` | integer | `2` | Delay between retries in seconds |
-
-#### IsolationForest Settings
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `isolation_forest.contamination` | float | `0.1` | Expected anomaly ratio (0.0-0.5) |
-| `isolation_forest.n_estimators` | integer | `100` | Number of trees |
-| `isolation_forest.random_state` | integer | `42` | Random seed |
-| `isolation_forest.max_samples` | string/int | `auto` | Samples per tree |
-
-#### Scaling Settings
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `scaling.cpu_scale_up_threshold` | integer | `70` | CPU % to trigger scale up |
-| `scaling.cpu_scale_down_threshold` | integer | `30` | CPU % to trigger scale down |
-| `scaling.cpu_scale_step` | integer | `1` | CPU cores per scaling action |
-| `scaling.ram_scale_up_threshold` | integer | `80` | RAM % to trigger scale up |
-| `scaling.ram_scale_down_threshold` | integer | `40` | RAM % to trigger scale down |
-| `scaling.ram_scale_step_mb` | integer | `512` | RAM MB per scaling action |
-| `scaling.min_cpu_cores` | integer | `1` | Minimum CPU cores |
-| `scaling.max_cpu_cores` | integer | `8` | Maximum CPU cores |
-| `scaling.min_ram_mb` | integer | `512` | Minimum RAM (MB) |
-| `scaling.max_ram_mb` | integer | `16384` | Maximum RAM (MB) |
-| `scaling.min_confidence` | integer | `0` | Minimum confidence (0-100) required to scale; 0 disables the check |
-| `scaling.dry_run` | boolean | `false` | Log scaling decisions without applying them |
-
-#### Circuit Breaker Settings
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `circuit_breaker.enabled` | boolean | `true` | Enable circuit breaker |
-| `circuit_breaker.failure_threshold` | integer | `5` | Failures before opening |
-| `circuit_breaker.timeout_seconds` | integer | `300` | Reset timeout |
-
-#### Other Settings
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `ignore_lxc` | list | `[]` | Container IDs to exclude |
-| `sleep_interval` | integer | `60` | Seconds between cycles |
-| `lock_file` | string | `/run/lxc_autoscale_ml.lock` | Single-instance lock; keep it out of world-writable `/tmp` |
-| `log_file` | string | `/var/log/lxc_autoscale_ml.log` | Rotated at 10 MB, 5 backups kept |
-
-## Monitor Configuration
-
-### Complete Reference
+Read by the metrics collector.
 
 ```yaml
 # /etc/lxc_autoscale_ml/lxc_monitor.yaml
-
-# Metrics Configuration
-metrics:
-  output_file: "/var/log/lxc_metrics.json"
-  max_entries: 1000        # Max entries in file
-  collection_interval: 10  # Seconds between collections
-
-# Logging Configuration
 logging:
-  log_level: "INFO"        # DEBUG, INFO, WARNING, ERROR
+  # Path to the file where log messages are written.
   log_file: "/var/log/lxc_monitor.log"
+  
+  # Maximum size of the log file before it is rotated (in bytes). Set to 5 MB here.
+  log_max_bytes: 5242880  # 5 MB
+  
+  # Number of backup log files to keep. Older files are deleted as new ones are created.
+  log_backup_count: 7
+  
+  # Logging level to determine the verbosity of log messages. Options include "DEBUG", "INFO", "WARNING", "ERROR", and "CRITICAL".
+  log_level: "INFO"
 
-# Container Filter
-containers:
-  ignore_stopped: true     # Skip stopped containers
-  ignore_templates: true   # Skip template containers
-
-# Performance
-performance:
-  batch_size: 10           # Containers per batch
-  timeout: 5               # Timeout per container
+monitoring:
+  # Path to the file where metrics data is exported in JSON format.
+  export_file: "/var/log/lxc_metrics.json"
+  
+  # Interval (in seconds) at which the monitoring checks are performed.
+  check_interval: 60  # seconds
+  
+  # Flag to enable or disable swap memory monitoring.
+  enable_swap: true
+  
+  # Flag to enable or disable network statistics monitoring.
+  enable_network: true
+  
+  # Flag to enable or disable filesystem statistics monitoring.
+  enable_filesystem: true
+  
+  # Flag to enable or disable parallel processing of monitoring tasks.
+  parallel_processing: true  # Toggle for parallel processing
+  
+  # Maximum number of parallel workers to use if parallel_processing is enabled.
+  max_workers: 8  # Max number of parallel workers if parallel_processing is enabled
+  
+  # List of device types to exclude from I/O statistics collection.
+  excluded_devices: ['loop', 'dm-']  # Devices to exclude in I/O stats
+  
+  # Maximum number of retry attempts for transient failures.
+  retry_limit: 3
+  
+  # Delay between retry attempts in seconds.
+  retry_delay: 2
+  
+  # Maximum number of metrics entries to keep in the export file (prevents unbounded growth).
+  max_metrics_entries: 1000  # Keeps last 1000 data points (~16 hours at 60s intervals)
 ```
 
-### Monitor Options
+## Option reference
+
+### API
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `metrics.output_file` | string | `/var/log/lxc_metrics.json` | Metrics output path |
-| `metrics.max_entries` | integer | `1000` | Maximum entries to keep |
-| `metrics.collection_interval` | integer | `10` | Collection interval (seconds) |
-| `containers.ignore_stopped` | boolean | `true` | Skip stopped containers |
-| `containers.ignore_templates` | boolean | `true` | Skip template containers |
-| `performance.batch_size` | integer | `10` | Containers per batch |
-| `performance.timeout` | integer | `5` | Timeout per container |
+| `server.host` | string | `0.0.0.0` | Address to bind. See the warning below. |
+| `server.port` | integer | `5000` | TCP port |
+| `lxc.node` | string | `proxmox` | Proxmox node name or IP |
+| `lxc.default_storage` | string | `local-lvm` | Storage used for clones |
+| `lxc.timeout_seconds` | integer | `10` | Timeout for each `pct`/`pvesh` call |
+| `rate_limiting.enabled` | boolean | `true` | Enable per-IP rate limiting |
+| `rate_limiting.max_requests_per_minute` | integer | `120` | Requests allowed per IP per window |
+| `rate_limiting.time_window_seconds` | integer | `60` | Sliding window length |
+| `authentication.enabled` | boolean | `false` | Require an API key |
+| `authentication.api_keys` | list | `[]` | Accepted keys |
+| `logging.level` | string | `INFO` | Minimum log level |
+| `logging.log_format` | string | see file | Python logging format string |
+| `logging.rotate` | boolean | `true` | Rotate `log_file` by size |
+| `logging.max_log_size_mb` | integer | `100` | Rotation threshold |
+| `logging.backup_count` | integer | `5` | Rotated files kept |
+| `error_handling.show_stack_traces` | boolean | `false` | Include exception detail in error responses |
+| `error_handling.log_errors` | boolean | `true` | Log handled errors |
+| `error_handling.notify_on_critical_errors` | boolean | `false` | Call the notification hook on 5xx |
+| `gunicorn.workers` | integer | `1` | Worker processes. See the warning below. |
+| `gunicorn.threads` | integer | `8` | Threads per worker |
+| `gunicorn.timeout_seconds` | integer | `120` | Worker timeout |
+| `gunicorn.graceful_timeout_seconds` | integer | `30` | Grace period on restart |
+| `gunicorn.max_requests` | integer | `500` | Requests before a worker is recycled |
+| `gunicorn.max_requests_jitter` | integer | `50` | Random spread on the above |
+| `gunicorn.preload_app` | boolean | `true` | Load the app before forking |
+| `gunicorn.log_level` | string | `info` | Gunicorn's own log level |
 
-## Configuration Validation
+`logging.log_file` is commented out in the shipped file. Leave it that way to
+log to stdout only, which systemd captures in the journal.
 
-The model validates configuration on startup. Common validation rules:
+::: warning The API runs as root
+It executes `pct` commands, so it has to. With the default
+`server.host: 0.0.0.0` it is reachable on every interface with no
+authentication. On the standard single-node layout, where the model runs beside
+it, set `server.host` to `127.0.0.1`. If it must be reachable from another host,
+enable `authentication` and put TLS in front of it.
+:::
 
-| Rule | Error Message |
-|------|---------------|
-| `min_cpu_cores > max_cpu_cores` | "min_cpu_cores cannot be greater than max_cpu_cores" |
-| `min_ram_mb > max_ram_mb` | "min_ram_mb cannot be greater than max_ram_mb" |
-| `cpu_scale_down_threshold >= cpu_scale_up_threshold` | "cpu_scale_down_threshold must be less than cpu_scale_up_threshold" |
-| Threshold outside 0-100 | "threshold must be between 0 and 100" |
+::: warning Keep gunicorn.workers at 1
+The rate limiter's per-IP window and the Prometheus counters live in process
+memory. Two worker processes means two independent rate limiters -- an effective
+limit of twice the configured value -- and `/metrics` reporting only whichever
+worker answered the scrape. The work here is waiting on `pct`, which releases
+the GIL, so `gunicorn.threads` gives you concurrency without splitting that
+state. Gunicorn logs a warning at startup if `workers` is above 1.
+:::
 
-### Validate Configuration Syntax
+### Model
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `log_file` | string | `/var/log/lxc_autoscale_ml.log` | Rotated at 10 MB, 5 backups kept |
+| `log_level` | string | `DEBUG` | Minimum log level |
+| `lock_file` | string | `/run/lxc_autoscale_ml.lock` | Single-instance lock. Keep it out of world-writable `/tmp`. |
+| `data_file` | string | `/var/log/lxc_metrics.json` | Metrics file written by the monitor |
+| `interval_seconds` | integer | `600` | Seconds between scaling cycles |
+| `api.api_url` | string | `http://127.0.0.1:5000` | Base URL of the API |
+| `api.cores_endpoint` | string | `/scale/cores` | CPU scaling endpoint |
+| `api.ram_endpoint` | string | `/scale/ram` | RAM scaling endpoint |
+| `api.timeout_seconds` | integer | `5` | Per-request timeout (`timeout` also accepted) |
+| `api.max_concurrent` | integer | `10` | Parallel configuration fetches |
+| `retry_logic.max_retries` | integer | `3` | Attempts per scaling request |
+| `retry_logic.retry_delay` | integer | `2` | Seconds between attempts |
+| `model.contamination` | float | `0.05` | Expected outlier fraction for IsolationForest |
+| `model.n_estimators` | integer | `100` | Trees in the forest |
+| `model.max_samples` | integer | `64` | Samples drawn per tree |
+| `model.random_state` | integer | `42` | Random seed |
+| `spike_detection.spike_threshold` | integer | `2` | Standard deviations that count as a spike |
+| `spike_detection.rolling_window` | integer | `5` | Window for rolling mean and standard deviation |
+| `scaling.max_cpu_cores` | integer | `4` | Ceiling per container |
+| `scaling.min_cpu_cores` | integer | `2` | Floor per container |
+| `scaling.max_ram_mb` | integer | `8192` | Ceiling per container |
+| `scaling.min_ram_mb` | integer | `1024` | Floor per container |
+| `scaling.cpu_scale_step` | integer | `1` | Cores added or removed per action |
+| `scaling.ram_scale_step_mb` | integer | `512` | MB added or removed per action |
+| `scaling.cpu_scale_up_threshold` | integer | `75` | CPU % above which to scale up |
+| `scaling.cpu_scale_down_threshold` | integer | `30` | CPU % below which to scale down |
+| `scaling.ram_scale_up_threshold` | integer | `75` | RAM % above which to scale up |
+| `scaling.ram_scale_down_threshold` | integer | `30` | RAM % below which to scale down |
+| `scaling.min_confidence` | integer | `0` | Confidence (0-100) required before acting; 0 disables the check |
+| `scaling.dry_run` | boolean | `false` | Log decisions without calling the API |
+| `circuit_breaker.enabled` | boolean | `true` | Stop calling the API for a container after repeated failures |
+| `circuit_breaker.failure_threshold` | integer | `3` | Consecutive failures before the circuit opens |
+| `circuit_breaker.timeout_seconds` | integer | `300` | How long it stays open |
+| `ignore_lxc` | list | `[]` | Container IDs to skip. Matched as strings, so `[101]` and `["101"]` both work. |
+
+On confidence: it is the distance of the prediction from the model's decision
+boundary, mapped onto 0-100. It is not a probability. Before v1.3.0 the formula
+produced roughly 50-150%, so it could not be compared against a percentage at
+all -- which is why `min_confidence` now defaults to 0 rather than the 70 this
+page used to claim.
+
+### Monitor
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `logging.log_file` | string | `/var/log/lxc_monitor.log` | Rotated by size |
+| `logging.log_max_bytes` | integer | `5242880` | Rotation threshold (5 MB) |
+| `logging.log_backup_count` | integer | `7` | Rotated files kept |
+| `logging.log_level` | string | `INFO` | Minimum log level |
+| `monitoring.export_file` | string | `/var/log/lxc_metrics.json` | Where metrics are written |
+| `monitoring.check_interval` | integer | `60` | Seconds between collection cycles |
+| `monitoring.enable_swap` | boolean | `true` | Collect swap usage |
+| `monitoring.enable_network` | boolean | `true` | Collect network counters |
+| `monitoring.enable_filesystem` | boolean | `true` | Collect filesystem usage |
+| `monitoring.parallel_processing` | boolean | `true` | Collect from containers concurrently |
+| `monitoring.max_workers` | integer | `8` | Thread pool size when parallel |
+| `monitoring.excluded_devices` | list | `['loop', 'dm-']` | Device prefixes skipped in I/O stats |
+| `monitoring.retry_limit` | integer | `3` | Attempts per probe before giving up |
+| `monitoring.retry_delay` | integer | `2` | Seconds between attempts |
+| `monitoring.max_metrics_entries` | integer | `1000` | Cycles kept in the export file |
+
+`monitoring.export_file` and the model's `data_file` must point at the same
+path. That file is the only thing connecting the two services.
+
+## Validation
+
+The model checks its scaling configuration at startup and refuses to run on a
+contradictory one:
+
+| Rule | Error |
+|------|-------|
+| `min_cpu_cores > max_cpu_cores` | `min_cpu_cores cannot be greater than max_cpu_cores` |
+| `min_ram_mb > max_ram_mb` | `min_ram_mb cannot be greater than max_ram_mb` |
+| A threshold is not a number | `<key> must be numeric, got <type>` |
+| A threshold is outside 0-100 | `<key> must be between 0 and 100, got <value>` |
+| `cpu_scale_down_threshold >= cpu_scale_up_threshold` | `cpu_scale_down_threshold must be less than cpu_scale_up_threshold` |
+| `ram_scale_down_threshold >= ram_scale_up_threshold` | `ram_scale_down_threshold must be less than ram_scale_up_threshold` |
+| A step size is zero or negative | `<key> must be positive` |
+
+`log_file`, `interval_seconds`, `api` and `api.api_url` are required; the rest
+falls back to the defaults above.
+
+To check a file parses at all:
 
 ```bash
 python3 -c "import yaml; yaml.safe_load(open('/etc/lxc_autoscale_ml/lxc_autoscale_ml.yaml'))"
 ```
 
-If there's no output, the YAML is valid.
+No output means valid YAML.
 
-## Example Configurations
+## Worked examples
 
-### Conservative Scaling
+### Cautious scaling
 
-Slower, more cautious scaling for production:
+Waits longer before acting, and only acts on confident predictions:
 
 ```yaml
 scaling:
   cpu_scale_up_threshold: 85
   cpu_scale_down_threshold: 20
   ram_scale_up_threshold: 90
-  ram_scale_down_threshold: 30
+  ram_scale_down_threshold: 25
   min_confidence: 80
 
-sleep_interval: 120
+interval_seconds: 900
 ```
 
-### Aggressive Scaling
+### Responsive scaling
 
-Faster response for development environments:
+For development hosts, where a wrong decision costs little:
 
 ```yaml
 scaling:
   cpu_scale_up_threshold: 60
   cpu_scale_down_threshold: 40
   ram_scale_up_threshold: 70
-  ram_scale_down_threshold: 50
-  min_confidence: 60
+  ram_scale_down_threshold: 45
+  min_confidence: 0
 
-sleep_interval: 30
+interval_seconds: 120
 ```
 
-### Large Deployment
+### Rehearsing a change
 
-Optimized for 60+ containers:
+`dry_run` logs the decision it would have taken and calls nothing:
+
+```yaml
+scaling:
+  dry_run: true
+```
+
+```
+[dry_run] Would scale container 104: CPU - Scale Up (-> 4), RAM - No Scaling | Confidence: 62.40%
+```
+
+### Many containers
 
 ```yaml
 api:
@@ -317,20 +500,18 @@ circuit_breaker:
   failure_threshold: 3
   timeout_seconds: 600
 
-sleep_interval: 120
+interval_seconds: 600
 ```
 
-## Applying Configuration Changes
+## Applying changes
 
-After modifying configuration files, restart the relevant service:
+Each service reads its file once, at startup:
 
 ```bash
-# API changes
-systemctl restart lxc_autoscale_api
-
-# Model changes
-systemctl restart lxc_autoscale_ml
-
-# Monitor changes
-systemctl restart lxc_monitor
+systemctl restart lxc_autoscale_api   # API changes
+systemctl restart lxc_autoscale_ml    # Model changes
+systemctl restart lxc_monitor         # Monitor changes
 ```
+
+The API also reloads on `SIGHUP` (`systemctl reload lxc_autoscale_api`), which
+restarts its workers without dropping the listening socket.

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -9,9 +9,9 @@ This page documents file locations, log files, and system paths for LXC AutoScal
 | Path | Description |
 |------|-------------|
 | `/usr/local/bin/lxc_autoscale_ml/` | Application code |
-| `/usr/local/bin/lxc_autoscale_ml/api/` | API component |
-| `/usr/local/bin/lxc_autoscale_ml/model/` | Model component |
-| `/usr/local/bin/lxc_autoscale_ml/monitor/` | Monitor component |
+| `/usr/local/bin/lxc_autoscale_api/` | API component |
+| `/usr/local/bin/lxc_autoscale_ml/` | Model component |
+| `/usr/local/bin/` | Monitor component |
 
 ### Configuration Files
 
@@ -36,9 +36,9 @@ This page documents file locations, log files, and system paths for LXC AutoScal
 | Path | Content |
 |------|---------|
 | `/var/log/lxc_autoscale_ml.log` | Model service main log |
-| `/var/log/autoscaleapi.log` | API main log |
-| `/var/log/autoscaleapi_access.log` | API access log |
-| `/var/log/autoscaleapi_error.log` | API error log |
+| `/var/log/lxc_autoscale_api.log` | API main log |
+| `/var/log/lxc_autoscale_api_access.log` | API access log |
+| `/var/log/lxc_autoscale_api_error.log` | API error log |
 | `/var/log/lxc_monitor.log` | Monitor service log |
 
 ### Data Files
@@ -51,7 +51,7 @@ This page documents file locations, log files, and system paths for LXC AutoScal
 
 | Path | Purpose |
 |------|---------|
-| `/var/lock/lxc_autoscale_ml.lock` | Model service instance lock |
+| `/run/lxc_autoscale_ml.lock` | Model service instance lock |
 
 ## Service Names
 
@@ -154,11 +154,11 @@ The application uses system Python packages installed via apt.
 
 ### Recommended Configuration
 
-Create `/etc/logrotate.d/lxc_autoscale`:
+Create `/etc/logrotate.d/lxc-autoscale-api`:
 
 ```
 /var/log/lxc_autoscale_ml.log
-/var/log/autoscaleapi*.log
+/var/log/lxc_autoscale_api_*.log
 /var/log/lxc_monitor.log {
     daily
     missingok
@@ -224,5 +224,5 @@ journalctl -u lxc_monitor -n 50
 ls -la /etc/lxc_autoscale_ml/
 ls -la /var/log/lxc_*.json
 ls -la /var/log/lxc_*.log
-ls -la /var/log/autoscaleapi*.log
+ls -la /var/log/lxc_autoscale_api_*.log
 ```

--- a/lxc_autoscale_ml/api/lxc_autoscale_api.yaml
+++ b/lxc_autoscale_ml/api/lxc_autoscale_api.yaml
@@ -120,6 +120,7 @@ gunicorn:
   # Random spread on max_requests. Irrelevant while max_requests is 0.
   max_requests_jitter: 0
 
-  # Access log format. Deliberately omits the query string, because ?api_key=
-  # is an accepted authentication method and this file is world-readable.
+  # Access log format. Deliberately omits the query string: the default format
+  # logs the whole request line, and this log is not a place for anything a
+  # caller passes as a parameter.
   access_log_format: '%(h)s "%(m)s %(U)s %(H)s" %(s)s %(b)s %(D)sus'

--- a/lxc_autoscale_ml/api/lxc_autoscale_api.yaml
+++ b/lxc_autoscale_ml/api/lxc_autoscale_api.yaml
@@ -13,17 +13,11 @@ lxc:
   # Name or IP address of the Proxmox node where LXC containers are managed.
   node: "proxmox"  # Replace with your Proxmox node name or IP. Note: if node name or hostname won't work use IP address instead, should work as expected.
   
-  # Whether to verify SSL certificates. Set to false for local commands.
-  verify_ssl: false  # Not applicable since we are using local commands
-  
   # Default storage location for LXC containers.
   default_storage: "local-lvm"  # Default storage location
   
   # Timeout for operations in seconds.
   timeout_seconds: 10
-  
-  # Maximum number of retry attempts for operations.
-  max_retries: 3
 
 rate_limiting:
   # Enable or disable rate limiting globally

--- a/lxc_autoscale_ml/model/lxc_autoscale_ml.yaml
+++ b/lxc_autoscale_ml/model/lxc_autoscale_ml.yaml
@@ -41,9 +41,6 @@ spike_detection:
 
 # Scaling Configuration
 scaling:
-  total_cores: 4  # Total number of CPU cores available on the server
-  total_ram_mb: 16384  # Total RAM available on the server in MB
-  target_cpu_load_percent: 50  # Target CPU load percentage after scaling
   max_cpu_cores: 4  # Maximum number of CPU cores to maintain per container
   max_ram_mb: 8192  # Maximum RAM to maintain per container in MB
   min_cpu_cores: 2  # Minimum number of CPU cores to maintain per container
@@ -54,9 +51,12 @@ scaling:
   cpu_scale_down_threshold: 30  # CPU usage percentage to trigger scale-down
   ram_scale_up_threshold: 75  # RAM usage percentage to trigger scale-up
   ram_scale_down_threshold: 30  # RAM usage percentage to trigger scale-down
-  ram_chunk_size: 50  # Minimum RAM scaling chunk size in MB
-  ram_upper_limit: 1024  # Maximum RAM scaling limit in one step in MB
-  dry_run: false  # If true, perform a dry run without making actual API calls
+  # Minimum confidence (0-100) required before a scaling action is applied.
+  # 0 disables the check. Confidence is the distance of the prediction from the
+  # model's decision boundary.
+  min_confidence: 0
+
+  dry_run: false  # If true, log scaling decisions without calling the API
 
 # API Configuration
 api:
@@ -79,15 +79,11 @@ retry_logic:
 # Interval Configuration
 interval_seconds: 600  # Time interval between consecutive script runs in seconds
 
-# Feature Engineering Configuration
-feature_engineering:
-  include_io_activity: true  # Include IO activity as a feature in the model
-  include_network_activity: true  # Include network activity as a feature in the model
-
-# Prediction Configuration
-prediction:
-  use_latest_only: false  # If true, use only the latest data point for prediction
-  include_rolling_features: true  # Include rolling mean and std features for prediction
+# Circuit Breaker for API calls
+circuit_breaker:
+  enabled: true  # Stop calling the API for a container after repeated failures
+  failure_threshold: 3  # Consecutive failures before the circuit opens
+  timeout_seconds: 300  # How long the circuit stays open before retrying
 
 # Ignored Containers
 ignore_lxc:

--- a/lxc_autoscale_ml/model/lxc_autoscale_ml.yaml
+++ b/lxc_autoscale_ml/model/lxc_autoscale_ml.yaml
@@ -86,8 +86,9 @@ circuit_breaker:
   timeout_seconds: 300  # How long the circuit stays open before retrying
 
 # Ignored Containers
-ignore_lxc:
-  # List container IDs to exclude from autoscaling
-  # Example: ["100", "999"] 
-  # Note: 101 and 102 are common first container IDs - don't ignore them by default!
-  []  # Empty list = scale all containers
+# Container IDs to exclude from autoscaling. An empty list scales everything.
+# IDs are matched as strings, so [101, 102] and ["101", "102"] both work.
+# Example: ignore_lxc: ["100", "999"]
+# Note: 101 and 102 are commonly the first containers on a host, so do not
+# ignore them out of habit.
+ignore_lxc: []

--- a/tests/test_config_contract.py
+++ b/tests/test_config_contract.py
@@ -1,0 +1,186 @@
+"""The shipped configuration files must match the code that reads them.
+
+Eleven keys shipped in the default configs and were read by nobody -- `dry_run`
+among them, so anyone rehearsing a change with it was scaling for real. These
+tests fail if a key is added to a config file without code to honour it, or if
+code starts reading a key the shipped file never mentions.
+"""
+import pathlib
+import re
+
+import pytest
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+CONFIGS = {
+    "api": ROOT / "lxc_autoscale_ml/api/lxc_autoscale_api.yaml",
+    "model": ROOT / "lxc_autoscale_ml/model/lxc_autoscale_ml.yaml",
+    "monitor": ROOT / "lxc_autoscale_ml/monitor/lxc_monitor.yaml",
+}
+SOURCE = "\n".join(
+    path.read_text() for path in (ROOT / "lxc_autoscale_ml").rglob("*.py")
+)
+
+# Keys whose consumer cannot be found by name because they are read through the
+# section dict rather than individually.
+READ_INDIRECTLY = {
+    "error_handling.notification_recipients",
+    "gunicorn.access_log_file",
+    "gunicorn.error_log_file",
+}
+
+
+def leaf_keys(node, prefix=""):
+    """Yield (dotted_path, leaf_name) for every scalar setting."""
+    if not isinstance(node, dict):
+        return
+    for key, value in node.items():
+        if isinstance(value, dict):
+            yield from leaf_keys(value, f"{prefix}{key}.")
+        else:
+            yield f"{prefix}{key}", key
+
+
+def is_read_by_code(leaf):
+    return bool(re.search(rf"""['"]{re.escape(leaf)}['"]""", SOURCE))
+
+
+@pytest.mark.parametrize("name", sorted(CONFIGS))
+def test_every_shipped_key_is_read_by_code(name):
+    config = yaml.safe_load(CONFIGS[name].read_text())
+    unread = [
+        dotted
+        for dotted, leaf in leaf_keys(config)
+        if dotted not in READ_INDIRECTLY and not is_read_by_code(leaf)
+    ]
+    assert not unread, (
+        f"{CONFIGS[name].name} ships keys no code reads: {unread}. "
+        f"Either honour them or take them out -- a setting that silently does "
+        f"nothing is worse than an absent one."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(CONFIGS))
+def test_configs_parse(name):
+    assert isinstance(yaml.safe_load(CONFIGS[name].read_text()), dict)
+
+
+class TestDocumentedKeysExist:
+    """Every key in the configuration reference must exist in a shipped file."""
+
+    REFERENCE = ROOT / "docs/reference/configuration.md"
+
+    def shipped_keys(self):
+        keys = set()
+        for path in CONFIGS.values():
+            config = yaml.safe_load(path.read_text())
+            for dotted, _ in leaf_keys(config):
+                keys.add(dotted)
+                keys.add(dotted.split(".")[-1])
+        return keys
+
+    def test_option_tables_reference_real_keys(self):
+        text = self.REFERENCE.read_text()
+        shipped = self.shipped_keys()
+        # Option tables use a leading `| `key`` cell.
+        documented = set(re.findall(r"^\|\s*`([a-z_]+(?:\.[a-z_]+)*)`\s*\|", text, re.M))
+        # Commented-out optional settings still count as shipped.
+        for path in CONFIGS.values():
+            for match in re.findall(r"^\s*#\s*([a-z_]+):", path.read_text(), re.M):
+                shipped.add(match)
+        unknown = sorted(
+            key for key in documented
+            if key not in shipped and key.split(".")[-1] not in shipped
+        )
+        assert not unknown, (
+            f"configuration.md documents settings that no shipped config has: {unknown}"
+        )
+
+
+class TestDocumentedYamlSnippets:
+    """YAML examples anywhere in the docs must use keys that exist.
+
+    The option tables were not enough: `isolation_forest:`, `sleep_interval:`
+    and `metrics_file:` lived on in copy-paste-ready snippets long after the
+    real keys had become `model:`, `interval_seconds:` and `data_file:`.
+    """
+
+    DOCS = sorted(
+        p for p in (ROOT / "docs").rglob("*.md")
+        if "node_modules" not in str(p) and ".vitepress" not in str(p)
+    )
+    # Keys belonging to other tools that legitimately appear in examples.
+    FOREIGN = {
+        "groups", "rules", "alert", "expr", "for", "labels", "annotations",
+        "severity", "summary", "description", "scrape_configs", "job_name",
+        "static_configs", "targets", "metrics_path", "scrape_interval",
+        "global", "evaluation_interval", "route", "receivers", "receiver",
+        "name", "url", "send_resolved", "webhook_configs", "repeat_interval",
+        "group_wait", "group_interval", "apiVersion", "kind", "metadata",
+        "spec", "image", "ports", "services", "volumes", "environment",
+        "version", "command", "container_name", "restart", "networks",
+        "healthcheck", "test", "interval", "timeout", "retries", "depends_on",
+        "build", "context", "dockerfile", "entrypoint", "user", "working_dir",
+    }
+
+    def shipped(self):
+        keys = set()
+        for path in CONFIGS.values():
+            text = path.read_text()
+            config = yaml.safe_load(text)
+            for dotted, leaf in leaf_keys(config):
+                keys.add(dotted)
+                keys.add(leaf)
+            keys.update(config.keys())
+            # Settings shipped commented out still count.
+            keys.update(re.findall(r"^\s*#\s*([a-z_]+):", text, re.M))
+        return keys
+
+    @pytest.mark.parametrize("doc", DOCS, ids=lambda p: p.name)
+    def test_yaml_examples_use_real_keys(self, doc):
+        shipped = self.shipped() | self.FOREIGN
+        unknown = set()
+        for block in re.findall(r"```yaml\n(.*?)```", doc.read_text(), re.S):
+            for key in re.findall(r"^\s*([a-z_][a-z0-9_]*):", block, re.M):
+                if key not in shipped:
+                    unknown.add(key)
+        assert not unknown, (
+            f"{doc.name} shows YAML settings that no shipped config has: "
+            f"{sorted(unknown)}"
+        )
+
+
+class TestServiceUnits:
+    """The systemd units must point at files the installer actually places."""
+
+    UNITS = sorted((ROOT / "lxc_autoscale_ml").rglob("*.service"))
+
+    def test_units_exist(self):
+        assert len(self.UNITS) == 3
+
+    @pytest.mark.parametrize("unit", UNITS, ids=lambda p: p.name)
+    def test_exec_start_target_is_installed(self, unit):
+        text = unit.read_text()
+        exec_start = re.search(r"^ExecStart=(.+)$", text, re.M)
+        assert exec_start, f"{unit.name} has no ExecStart"
+
+        install = (ROOT / "install.sh").read_text()
+        for token in exec_start.group(1).split():
+            if not token.startswith("/"):
+                continue
+            name = pathlib.Path(token).name
+            if name in ("python3", "gunicorn"):
+                # Provided by a package; install.sh must ask for it.
+                assert name in install, f"{name} is not installed by install.sh"
+                continue
+
+            # The file has to exist in the repository...
+            sources = list((ROOT / "lxc_autoscale_ml").rglob(name))
+            assert sources, f"{unit.name} runs {token}, which is not in this repository"
+
+            # ...and install.sh has to place it, by name or by directory glob.
+            source_dir = sources[0].parent.name
+            placed = name in install or f"/{source_dir}/\"*.py" in install
+            assert placed, (
+                f"{unit.name} runs {token}, which install.sh never puts there"
+            )

--- a/tests/test_config_contract.py
+++ b/tests/test_config_contract.py
@@ -17,9 +17,10 @@ CONFIGS = {
     "model": ROOT / "lxc_autoscale_ml/model/lxc_autoscale_ml.yaml",
     "monitor": ROOT / "lxc_autoscale_ml/monitor/lxc_monitor.yaml",
 }
-SOURCE = "\n".join(
-    path.read_text() for path in (ROOT / "lxc_autoscale_ml").rglob("*.py")
-)
+SOURCES = {
+    path: path.read_text() for path in (ROOT / "lxc_autoscale_ml").rglob("*.py")
+}
+SOURCE = "\n".join(SOURCES.values())
 
 # Keys whose consumer cannot be found by name because they are read through the
 # section dict rather than individually.
@@ -41,8 +42,39 @@ def leaf_keys(node, prefix=""):
             yield f"{prefix}{key}", key
 
 
-def is_read_by_code(leaf):
-    return bool(re.search(rf"""['"]{re.escape(leaf)}['"]""", SOURCE))
+def quoted(name, text):
+    return bool(re.search(rf"""['"]{re.escape(name)}['"]""", text))
+
+
+def ambiguous_leaves():
+    """Leaf names that appear under more than one section, anywhere.
+
+    For these, finding the leaf in the source proves nothing: `max_retries`
+    lives under both `lxc` and `retry_logic`, and only the second is read. That
+    is how `lxc.max_retries` passed this check while doing nothing.
+    """
+    seen = {}
+    for path in CONFIGS.values():
+        for dotted, leaf in leaf_keys(yaml.safe_load(path.read_text())):
+            seen.setdefault(leaf, set()).add(dotted)
+    return {leaf for leaf, paths in seen.items() if len(paths) > 1}
+
+
+AMBIGUOUS = ambiguous_leaves()
+
+
+def is_read_by_code(dotted, leaf):
+    if leaf not in AMBIGUOUS:
+        return quoted(leaf, SOURCE)
+
+    # Ambiguous leaf: require some module to mention both the section and the
+    # leaf, so a setting cannot borrow another section's consumer.
+    section = dotted.rsplit(".", 1)[0] if "." in dotted else None
+    if section is None:
+        return quoted(leaf, SOURCE)
+    return any(
+        quoted(section, text) and quoted(leaf, text) for text in SOURCES.values()
+    )
 
 
 @pytest.mark.parametrize("name", sorted(CONFIGS))
@@ -51,7 +83,7 @@ def test_every_shipped_key_is_read_by_code(name):
     unread = [
         dotted
         for dotted, leaf in leaf_keys(config)
-        if dotted not in READ_INDIRECTLY and not is_read_by_code(leaf)
+        if dotted not in READ_INDIRECTLY and not is_read_by_code(dotted, leaf)
     ]
     assert not unread, (
         f"{CONFIGS[name].name} ships keys no code reads: {unread}. "

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -1,0 +1,171 @@
+"""The documentation must describe the software that exists.
+
+Before v1.3.0 the docs described API-key authentication and a /metrics endpoint
+that were never wired up, metric names that appear nowhere in the code, eight
+monitor settings that no configuration file has, and a `gunicorn` section the
+systemd unit ignored. These tests fail when the docs and the code drift apart
+again.
+"""
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DOCS = sorted(
+    p for p in ROOT.rglob("*.md")
+    if "node_modules" not in str(p) and ".vitepress" not in str(p)
+)
+
+
+@pytest.fixture(scope="module")
+def flask_app():
+    import config as api_config
+
+    original = api_config.load_config
+    api_config.load_config = lambda *a, **kw: {
+        "lxc": {"node": "proxmox", "timeout_seconds": 10},
+        "logging": {},
+        "error_handling": {},
+    }
+    try:
+        import lxc_autoscale_api
+        yield lxc_autoscale_api.app
+    finally:
+        api_config.load_config = original
+
+
+@pytest.fixture(scope="module")
+def real_routes(flask_app):
+    return {
+        str(rule) for rule in flask_app.url_map.iter_rules()
+        if not str(rule).startswith("/static")
+    }
+
+
+class TestEndpoints:
+    ENDPOINT = re.compile(
+        r"/(?:scale|snapshot|clone|resource|health|metrics|routes)(?:/[a-z_]+)*"
+    )
+
+    def test_documented_endpoints_exist(self, real_routes):
+        documented = set()
+        for doc in DOCS:
+            if doc.name == "CHANGELOG.md":
+                continue  # history may mention paths that have since changed
+            text = doc.read_text()
+            for match in self.ENDPOINT.finditer(text):
+                path = match.group()
+                # `/resource/lxc/*` names a family of routes in prose, not a
+                # route. Checked here rather than with a lookahead, which the
+                # engine satisfies by backtracking off the last character.
+                if text[match.end():match.end() + 2] in ("/*", "*"):
+                    continue
+                # Bare prefixes like `/resource` also appear in prose.
+                if path.count("/") >= 2 or path in ("/metrics", "/routes"):
+                    documented.add(path)
+        unknown = sorted(documented - real_routes)
+        assert not unknown, f"documented endpoints that do not exist: {unknown}"
+
+    def test_every_route_is_documented(self, real_routes):
+        reference = (ROOT / "docs/reference/api-endpoints.md").read_text()
+        undocumented = sorted(
+            route for route in real_routes
+            if route != "/" and route not in reference
+        )
+        assert not undocumented, (
+            f"routes missing from the API reference: {undocumented}"
+        )
+
+
+class TestMetricNames:
+    def test_documented_metrics_exist(self):
+        source = (ROOT / "lxc_autoscale_ml/api/metrics.py").read_text()
+        declared = set(re.findall(r"'(lxc_autoscale_[a-z_]+)'", source))
+        assert declared, "no metrics found in metrics.py"
+
+        reference = (ROOT / "docs/reference/metrics.md").read_text()
+        mentioned = set(re.findall(r"\b(lxc_autoscale_[a-z_]+)\b", reference))
+
+        # Prometheus appends _total/_bucket/_sum/_count to the base names.
+        def base(name):
+            for suffix in ("_total", "_bucket", "_sum", "_count", "_created"):
+                if name.endswith(suffix):
+                    return name[: -len(suffix)]
+            return name
+
+        unknown = sorted(
+            name for name in mentioned
+            if base(name) not in declared and name not in declared
+        )
+        assert not unknown, (
+            f"metrics.md documents metrics that metrics.py does not declare: {unknown}"
+        )
+
+    def test_no_stale_metric_prefix(self):
+        """The old docs used `lxc_` where the code uses `lxc_autoscale_`."""
+        for doc in DOCS:
+            if doc.name == "CHANGELOG.md":
+                continue
+            text = doc.read_text()
+            stale = re.findall(r"\blxc_(?!autoscale|monitor|metrics)[a-z_]*(?:_total|_state)\b", text)
+            assert not stale, f"{doc.name} uses stale metric names: {set(stale)}"
+
+
+class TestServiceNames:
+    UNITS = {"lxc_autoscale_api", "lxc_autoscale_ml", "lxc_monitor"}
+
+    def test_documented_units_exist(self):
+        shipped = {p.stem for p in (ROOT / "lxc_autoscale_ml").rglob("*.service")}
+        assert shipped == self.UNITS
+
+        mentioned = set()
+        for doc in DOCS:
+            mentioned |= set(re.findall(r"systemctl \w+ ([a-z_]+)\.service", doc.read_text()))
+            mentioned |= set(re.findall(r"journalctl -u ([a-z_]+)", doc.read_text()))
+        unknown = sorted(mentioned - self.UNITS)
+        assert not unknown, f"docs reference services that do not exist: {unknown}"
+
+
+class TestPythonVersionIsConsistent:
+    def test_docs_agree_with_ci(self):
+        ci = (ROOT / ".github/workflows/ci.yml").read_text()
+        versions = set(re.findall(r"'(3\.\d+)'", ci))
+        assert "3.13" not in versions, (
+            "CI claims 3.13 support, but the pinned numpy/pandas/scikit-learn "
+            "have no 3.13 wheels"
+        )
+
+        for path in ["README.md", "docs/guide/requirements.md", "docs/index.md"]:
+            text = (ROOT / path).read_text()
+            assert "3.10" in text and "3.12" in text, (
+                f"{path} does not state the supported Python range"
+            )
+            assert "Python 3.x" not in text, f"{path} still says 'Python 3.x'"
+
+
+class TestNoMarketingClaims:
+    """Unverifiable superlatives and invented benchmarks."""
+
+    BANNED = [
+        r"\b10x\b", r"\benterprise[- ]grade\b", r"\bEnterprise Security\b",
+        r"\bproduction[- ]ready\b", r"\bblazing\b", r"\bworld[- ]class\b",
+        r"\bzero downtime\b", r"\bhigh accuracy\b", r"\bseamless\b",
+    ]
+
+    @pytest.mark.parametrize("doc", DOCS, ids=lambda p: str(p.relative_to(ROOT)))
+    def test_doc_is_free_of_claims(self, doc):
+        if doc.name == "CHANGELOG.md":
+            pytest.skip("historical entries are left as written")
+        text = doc.read_text()
+        found = [p for p in self.BANNED if re.search(p, text, re.I)]
+        assert not found, f"{doc.name} contains unverifiable claims: {found}"
+
+
+class TestNoEmoji:
+    EMOJI = re.compile("[\U0001F300-\U0001FAFF☀-⛿✀-➿⬀-⯿]")
+
+    @pytest.mark.parametrize("doc", DOCS, ids=lambda p: str(p.relative_to(ROOT)))
+    def test_doc_is_free_of_emoji(self, doc):
+        found = self.EMOJI.findall(doc.read_text())
+        assert not found, f"{doc.name} contains emoji: {sorted(set(found))}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -197,3 +197,159 @@ class TestNoEmoji:
     def test_doc_is_free_of_emoji(self, doc):
         found = self.EMOJI.findall(doc.read_text())
         assert not found, f"{doc.name} contains emoji: {sorted(set(found))}"
+
+
+class TestDocumentedDefaults:
+    """Existence checks were not enough.
+
+    The previous guards asserted that a documented key *exists*. They said
+    nothing about its value, so `docs/components/model.md` could claim a default
+    of 70% while the shipped file said 75, and a whole page could be regenerated
+    from a stale copy of the YAML without failing anything.
+    """
+
+    # `key (default N)` in prose, and the Default column of an option table.
+    PROSE = re.compile(r'`?([a-z][a-z_0-9]{3,})`?\s*\(default[:\s]+`?([0-9]+)', re.I)
+    TABLE = re.compile(r'^\|\s*`([a-z_][a-z_.0-9]*)`\s*\|[^|]*\|\s*`?([^|`]+?)`?\s*\|', re.M)
+
+    def shipped_values(self):
+        import yaml
+
+        values = {}
+
+        def walk(node, prefix=""):
+            for key, value in (node or {}).items():
+                if isinstance(value, dict):
+                    walk(value, f"{prefix}{key}.")
+                else:
+                    values.setdefault(key, set()).add(str(value).lower())
+                    values.setdefault(f"{prefix}{key}", set()).add(str(value).lower())
+
+        for path in (ROOT / "lxc_autoscale_ml").rglob("*.yaml"):
+            walk(yaml.safe_load(path.read_text()))
+        return values
+
+    @pytest.mark.parametrize("doc", DOCS, ids=lambda p: str(p.relative_to(ROOT)))
+    def test_declared_defaults_match_the_shipped_configuration(self, doc):
+        if doc.name == "CHANGELOG.md":
+            pytest.skip("historical entries describe past defaults")
+        shipped = self.shipped_values()
+        text = doc.read_text()
+        wrong = []
+        for pattern in (self.PROSE, self.TABLE):
+            for match in pattern.finditer(text):
+                key, value = match.group(1), match.group(2).strip().lower()
+                if key not in shipped or value in ("-", "see file", ""):
+                    continue
+                if value not in shipped[key]:
+                    wrong.append(f"{key}: documented {value!r}, shipped {sorted(shipped[key])}")
+        assert not wrong, f"{doc.name} states defaults the configuration does not have: {wrong}"
+
+
+class TestDocumentedPaths:
+    """Six pages sent operators to /var/lock for a lock file kept in /run, so
+    the documented stale-lock recovery could not work."""
+
+    PATH = re.compile(r'(/(?:etc|usr|var|run|opt)/[\w./-]+)')
+
+    # Paths that legitimately are not ours. Each is something the reader is
+    # told to create, something Proxmox owns, or illustrative output in an
+    # example script -- never a path we claim to install.
+    ALLOWED_PREFIXES = (
+        "/var/lib/lxcfs", "/usr/bin/lxcfs",      # Proxmox
+        "/etc/ssl/",                              # the reader's TLS material
+        "/etc/logrotate.d/",                      # a stanza the reader writes
+        "/etc/apt", "/var/log/syslog",
+        "/usr/bin/python3", "/usr/bin/gunicorn", "/usr/bin/env",
+    )
+    # Output files produced by the example scripts, not by this software.
+    ALLOWED_EXACT = {
+        "/var/log/container_104_status.log", "/var/log/node_status.log",
+    }
+
+    def ours(self):
+        import re as _re
+
+        paths = set()
+        sources = [ROOT / "install.sh", ROOT / "uninstall.sh"]
+        sources += list((ROOT / "lxc_autoscale_ml").rglob("*.py"))
+        sources += list((ROOT / "lxc_autoscale_ml").rglob("*.yaml"))
+        sources += list((ROOT / "lxc_autoscale_ml").rglob("*.service"))
+        for path in sources:
+            paths |= set(_re.findall(r'(/(?:etc|usr|var|run|opt)/[\w./*-]+)', path.read_text()))
+        return {p.rstrip("/") for p in paths}
+
+    @pytest.mark.parametrize("doc", DOCS, ids=lambda p: str(p.relative_to(ROOT)))
+    def test_documented_paths_exist_in_the_deployment(self, doc):
+        if doc.name == "CHANGELOG.md":
+            pytest.skip("historical entries describe paths that have since moved")
+        ours = self.ours()
+        unknown = set()
+        for match in self.PATH.finditer(doc.read_text()):
+            path = match.group(1).rstrip("/.")
+            if path in ours or path in self.ALLOWED_EXACT:
+                continue
+            if path.startswith(self.ALLOWED_PREFIXES):
+                continue
+            # A glob in the docs (`lxc_autoscale_api_*.log`) leaves its stem
+            # behind once the metacharacter is stripped.
+            if any(real.startswith(path) for real in ours):
+                continue
+            # A directory prefix of something we install is fine.
+            if any(real.startswith(path + "/") for real in ours):
+                continue
+            # Backups and derived names the reader creates.
+            if any(path.endswith(suffix) for suffix in
+                   (".backup", ".bak", ".new", ".corrupt", ".tmp", ".save")):
+                continue
+            unknown.add(path)
+        assert not unknown, (
+            f"{doc.name} names paths this deployment never creates: {sorted(unknown)}"
+        )
+
+
+class TestAuthenticationClaims:
+    """Four pages asserted as fact that the root-privileged API is protected by
+    authentication. It ships disabled."""
+
+    def test_no_page_claims_authentication_is_on_by_default(self):
+        import yaml
+
+        shipped = yaml.safe_load(
+            (ROOT / "lxc_autoscale_ml/api/lxc_autoscale_api.yaml").read_text())
+        assert shipped["authentication"]["enabled"] is False, (
+            "the shipped default changed; this test and the docs need revisiting"
+        )
+
+        claims = re.compile(
+            r"protected by (?:an )?API[- ]key|is protected by authentication|"
+            r"authentication is (?:enabled|required) by default", re.I)
+        offenders = [str(d.relative_to(ROOT)) for d in DOCS
+                     if d.name != "CHANGELOG.md" and claims.search(d.read_text())]
+        assert not offenders, (
+            f"these pages assert the API is authenticated, but it ships with "
+            f"authentication disabled: {offenders}"
+        )
+
+    def test_no_runnable_example_uses_the_query_parameter_form(self):
+        """It was removed because it wrote the key into the access log.
+
+        Checked inside fenced blocks only: prose explaining the removal is
+        exactly what this page should contain.
+        """
+        offenders = []
+        for doc in DOCS:
+            if doc.name == "CHANGELOG.md":
+                continue
+            for block in re.findall(r"```[a-z]*\n(.*?)```", doc.read_text(), re.S):
+                if re.search(r"[?&]api_key=", block):
+                    offenders.append(str(doc.relative_to(ROOT)))
+                    break
+        assert not offenders, (
+            f"?api_key= is no longer accepted, but these pages still show it in a "
+            f"runnable example: {offenders}"
+        )
+
+    def test_the_source_agrees(self):
+        source = (ROOT / "lxc_autoscale_ml/api/authentication.py").read_text()
+        assert "request.args.get('api_key')" not in source

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -68,10 +68,13 @@ class TestEndpoints:
         assert not unknown, f"documented endpoints that do not exist: {unknown}"
 
     def test_every_route_is_documented(self, real_routes):
+        """Compared as whole strings: with a substring check, `/scale/core`
+        would look documented because `/scale/cores` is present."""
         reference = (ROOT / "docs/reference/api-endpoints.md").read_text()
+        documented = set(self.ENDPOINT.findall(reference))
         undocumented = sorted(
             route for route in real_routes
-            if route != "/" and route not in reference
+            if route != "/" and route not in documented
         )
         assert not undocumented, (
             f"routes missing from the API reference: {undocumented}"
@@ -128,20 +131,45 @@ class TestServiceNames:
 
 
 class TestPythonVersionIsConsistent:
-    def test_docs_agree_with_ci(self):
-        ci = (ROOT / ".github/workflows/ci.yml").read_text()
-        versions = set(re.findall(r"'(3\.\d+)'", ci))
-        assert "3.13" not in versions, (
-            "CI claims 3.13 support, but the pinned numpy/pandas/scikit-learn "
-            "have no 3.13 wheels"
-        )
+    """The docs must state whatever range CI actually tests.
 
-        for path in ["README.md", "docs/guide/requirements.md", "docs/index.md"]:
+    Derived from the matrix rather than pinned to specific versions, so raising
+    the floor or the ceiling does not require editing this test -- it requires
+    editing the docs, which is the point.
+    """
+
+    DOCS_STATING_THE_RANGE = [
+        "README.md", "docs/guide/requirements.md", "docs/index.md",
+    ]
+
+    def matrix_versions(self):
+        ci = (ROOT / ".github/workflows/ci.yml").read_text()
+        matrix = re.search(r"python-version:\s*\[([^\]]+)\]", ci)
+        assert matrix, "could not find the python-version matrix in ci.yml"
+        versions = re.findall(r"3\.\d+", matrix.group(1))
+        assert versions, "the python-version matrix is empty"
+        return versions
+
+    def test_docs_state_the_tested_range(self):
+        versions = self.matrix_versions()
+        floor, ceiling = versions[0], versions[-1]
+
+        for path in self.DOCS_STATING_THE_RANGE:
             text = (ROOT / path).read_text()
-            assert "3.10" in text and "3.12" in text, (
-                f"{path} does not state the supported Python range"
+            assert floor in text and ceiling in text, (
+                f"CI tests Python {floor} to {ceiling}, but {path} does not "
+                f"state that range"
             )
             assert "Python 3.x" not in text, f"{path} still says 'Python 3.x'"
+
+    def test_requirements_agree_with_the_matrix(self):
+        """The stated floor has to be installable, not aspirational."""
+        stated = (ROOT / "requirements.txt").read_text()
+        floor, ceiling = self.matrix_versions()[0], self.matrix_versions()[-1]
+        assert f"{floor}-{ceiling}" in stated, (
+            f"requirements.txt should record the supported range "
+            f"({floor}-{ceiling}) so it is visible where the pins are"
+        )
 
 
 class TestNoMarketingClaims:


### PR DESCRIPTION
A 1:1 audit of the documentation against the codebase, with tests so they cannot
drift apart again.

## The one that matters

**`authentication.api_key` never existed.** The getting-started guide, the
installation guide, the upgrade guide and the API component page all told
readers to set it:

```yaml
authentication:
  enabled: true
  api_key: "your-secure-api-key-here"   # read by nothing
```

The code reads `authentication.api_keys`, a list. Anyone who followed those
instructions ended up with a configuration the API ignored, believing
authentication was on.

## Configuration that was read by nobody

Twelve more keys shipped in the defaults and had no effect. Removed:

`lxc.verify_ssl` · `lxc.max_retries` · `scaling.total_cores` ·
`scaling.total_ram_mb` · `scaling.target_cpu_load_percent` ·
`scaling.ram_chunk_size` · `scaling.ram_upper_limit` · the whole
`feature_engineering` and `prediction` sections

The five `scaling.*` ones describe a capacity-planning algorithm this project
does not implement.

Conversely, `circuit_breaker` and `scaling.min_confidence` **are** read by the
code and were missing from the shipped file. Added.

## Documentation that described other software

| Where | What it said | Reality |
|---|---|---|
| Monitor reference | `metrics` / `containers` / `performance` sections | Has never existed; the file uses `monitoring` and `logging` |
| Model reference | `isolation_forest`, `sleep_interval`, `data.metrics_file`, `retry_attempts` | `model`, `interval_seconds`, `data_file`, `retry_logic.max_retries` |
| Every PromQL query | `lxc_scaling_actions_total`, `lxc_api_request_duration_seconds` | `lxc_autoscale_*` |
| Metric labels | `action="scale_up"` / `"scale_down"` | `set` / `increase`; direction is not recorded |
| API component | "Configuration Management: dynamically update scaling configurations" | No such endpoint |
| Monitor component | "Anomaly Detection", "Threshold Alerts" | Both belong to the model; the monitor only records |

Every query and alert rule in the docs was unusable as written.

## Invented benchmarks

The docs carried this table:

| Containers | Sequential | Async Batch | Speedup |
|---|---|---|---|
| 50 | 5.0s | 0.50s | 10x |
| 100 | 10.0s | 1.0s | 10x |

No methodology, no hardware, no measurement — for an endpoint that returned an
error on **every** call until v1.3.0, so nobody could have measured it. Replaced
with a description of the mechanism and a pointer to the timing each cycle
already logs.

Also removed: "Enterprise Security" (for authentication that was off by default
and not wired up), "Production-Ready" (for software that had never worked),
"zero downtime", "high accuracy", "seamless", "comprehensive", and all emoji.

## Keeping it honest

`docs/reference/configuration.md` is now generated from the shipped YAML files,
so the reference and the artefact cannot disagree.

40 new tests in `tests/test_config_contract.py` and `tests/test_docs_contract.py`
fail if:

- a configuration file grows a key no code reads
- the docs document a setting, endpoint or metric that does not exist
- a YAML example anywhere in the docs uses an unknown key
- a route exists that the API reference does not list
- a systemd unit points at a file the installer never places
- the stated Python range drifts from the CI matrix
- emoji or the banned claims come back

Two of these caught real problems while being written: `lxc_scaling_actions_total`
in the README, and the `isolation_forest` / `sleep_interval` snippets that the
option-table check alone had missed.

## Verification

301 tests pass, `ruff` clean, `shellcheck` clean, the docs site builds, and no
broken internal links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
