### PR TITLE
fix(model): the autoscaler scaled every container down regardless of load

### DIFF
--- a/lxc_autoscale_ml/api/lxc_management.py
+++ b/lxc_autoscale_ml/api/lxc_management.py
@@ -139,16 +139,29 @@ class LXCManager:
         )
 
     def get_current_resources(self, lxc_id):
-        """Return (cores, memory_mb) for a container."""
+        """Return (cores, memory_mb) for a container.
+
+        Either may be None. `cores` in particular is OPTIONAL in Proxmox --
+        `pct create` without `--cores` leaves it unset, meaning "all host
+        cores" -- and treating its absence as an error made
+        /resource/lxc/config return 500 for such a container forever, which in
+        turn drove the scaling loop down its guess-the-allocation path.
+        A missing value is a fact about the container, not a failure.
+        """
         config = self.get_config(lxc_id)
-        try:
-            cores = int(config["cores"])
-            memory = int(config["memory"])
-        except (KeyError, ValueError) as e:
-            raise RuntimeError(
-                f"Failed to retrieve current resources for container {lxc_id}: {e}"
-            ) from e
-        return cores, memory
+
+        def optional_int(key):
+            raw = config.get(key)
+            if raw is None:
+                return None
+            try:
+                return int(raw)
+            except ValueError:
+                logging.warning(
+                    f"Container {lxc_id} reports a non-numeric {key}: {raw!r}")
+                return None
+
+        return optional_int("cores"), optional_int("memory")
 
     def resize_storage(self, lxc_id, disk_size):
         """Grow the root filesystem by `disk_size` GB."""

--- a/lxc_autoscale_ml/model/data_manager.py
+++ b/lxc_autoscale_ml/model/data_manager.py
@@ -2,7 +2,6 @@ import pandas as pd
 import logging
 import json
 import numpy as np
-from sklearn.preprocessing import StandardScaler
 
 def load_data(file_path):
     try:
@@ -145,14 +144,20 @@ def preprocess_data(df, config):
         df['min_memory'] = df.groupby('container_id')['memory_usage_mb'].transform(
             lambda x: x.rolling(window=rolling_window_size, min_periods=1).min())
 
-        # Feature scaling
-        scaler = StandardScaler()
-        features_to_scale = [
-            'cpu_usage_percent', 'memory_usage_mb', 'cpu_per_process', 'memory_per_process', 'time_diff',
-            'cpu_trend', 'memory_trend', 'max_cpu', 'min_cpu', 'max_memory', 'min_memory',
-            'cpu_memory_ratio'
-        ]
-        df[features_to_scale] = scaler.fit_transform(df[features_to_scale])
+        # Deliberately NOT scaled here.
+        #
+        # This function used to standard-scale twelve columns in place, two of
+        # which -- cpu_usage_percent and memory_usage_mb -- are read by
+        # determine_scaling_action and compared against percentage thresholds.
+        # A z-score never exceeds cpu_scale_up_threshold (75) and is almost
+        # always below cpu_scale_down_threshold (30), so every container was
+        # scaled DOWN on both axes every cycle regardless of real load. A
+        # container at 99% CPU produced the same decision as one at 3%.
+        #
+        # The scaling was also redundant: train_anomaly_models wraps
+        # IsolationForest in Pipeline([('scaler', StandardScaler()), ...]) and
+        # fits it on this same frame, so the model standardises its own inputs
+        # and its features are unchanged by this removal.
 
         logging.info("Feature engineering, spike detection, and trend detection completed.")
     except Exception:

--- a/lxc_autoscale_ml/model/lxc_autoscale_ml.py
+++ b/lxc_autoscale_ml/model/lxc_autoscale_ml.py
@@ -3,6 +3,8 @@
 import logging
 import sys
 import time
+
+import pandas as pd
 from collections import defaultdict
 from datetime import datetime, timedelta
 
@@ -90,6 +92,38 @@ def ignored_container_ids(config):
     return {str(container_id) for container_id in config.get("ignore_lxc") or []}
 
 
+def current_container_ids(df):
+    """Container IDs present in the most recent snapshot.
+
+    The metrics file keeps `max_metrics_entries` cycles of history and the
+    monitor only records running containers, so a container's rows linger long
+    after it stops existing.
+    """
+    latest = df["timestamp"].max()
+    return [str(cid) for cid in df[df["timestamp"] == latest]["container_id"].unique()]
+
+
+def metrics_are_stale(df, config):
+    """True when the newest sample is too old to scale on.
+
+    The monitor can wedge or die while the model keeps running. Without this
+    check the model retrains and scales on a frozen snapshot forever, and
+    because each target is absolute and derived from the live allocation, the
+    allocation ratchets towards a limit on every cycle.
+    """
+    interval = config.get("interval_seconds", 60)
+    max_age = config.get("max_metrics_age_seconds", interval * 3)
+    newest = df["timestamp"].max()
+    age = (pd.Timestamp.now() - newest).total_seconds()
+    if age > max_age:
+        logging.error(
+            f"Newest metrics sample is {age:.0f}s old (limit {max_age:.0f}s). "
+            f"The monitor may be stopped or wedged; refusing to scale on stale data."
+        )
+        return True
+    return False
+
+
 def run_cycle(config, circuit_breaker=None):
     """
     Run one full collection -> prediction -> scaling pass.
@@ -109,6 +143,9 @@ def run_cycle(config, circuit_breaker=None):
         logging.error("Preprocessing produced no usable data; skipping this cycle.")
         return False
 
+    if metrics_are_stale(df, config):
+        return False
+
     model, features_to_use = train_anomaly_models(df, config)
     if model is None:
         logging.error("Model training failed; skipping this cycle.")
@@ -120,7 +157,13 @@ def run_cycle(config, circuit_breaker=None):
     # object keys. Comparing the column against int(container_id) matched no
     # rows at all, so the very first container raised IndexError and killed
     # the whole run.
-    container_ids = [str(cid) for cid in df["container_id"].unique()]
+    #
+    # Only containers present in the NEWEST snapshot are evaluated. Taking
+    # unique() over the whole retained history evaluated containers that were
+    # stopped or destroyed hours ago -- and, because Proxmox reuses VMIDs, a
+    # brand new container could be scaled on its predecessor's metrics until
+    # the old rows aged out of the window.
+    container_ids = current_container_ids(df)
 
     ignored = ignored_container_ids(config)
     if ignored:
@@ -184,7 +227,6 @@ def run_cycle(config, circuit_breaker=None):
 def evaluate_container(container_id, df, model, features_to_use, container_config,
                        config, dry_run, min_confidence):
     """Decide and, unless dry_run is set, apply scaling for one container."""
-    scaling_config = config["scaling"]
     container_data = df[df["container_id"] == container_id]
     if container_data.empty:
         logging.warning(f"No metrics rows for container {container_id}; skipping.")
@@ -192,20 +234,26 @@ def evaluate_container(container_id, df, model, features_to_use, container_confi
 
     latest_metrics = container_data.iloc[-1].copy()
 
-    if container_config:
-        latest_metrics["current_cores"] = container_config.get(
-            "cores", scaling_config["min_cpu_cores"])
-        latest_metrics["current_ram_mb"] = container_config.get(
-            "memory_mb", scaling_config["min_ram_mb"])
-        logging.debug(
-            f"Container {container_id} current config: "
-            f"{container_config.get('cores')} cores, "
-            f"{container_config.get('memory_mb')} MB RAM"
+    # Every target this function computes is ABSOLUTE -- `pct set -cores N`,
+    # not a delta -- and every one is derived from the container's current
+    # allocation. Substituting the configured minimum when the fetch failed
+    # therefore does not degrade gracefully: it writes the container down to
+    # the floor in a single cycle, and the write is self-masking because the
+    # next fetch then reports the value we just imposed. Skip instead.
+    cores = (container_config or {}).get("cores")
+    memory_mb = (container_config or {}).get("memory_mb")
+    if cores is None or memory_mb is None:
+        logging.warning(
+            f"Skipping container {container_id}: its current allocation is unknown "
+            f"({'no response from the API' if not container_config else 'response missing cores/memory_mb'}). "
+            f"Scaling from a guessed allocation would resize it to the wrong absolute value."
         )
-    else:
-        latest_metrics["current_cores"] = scaling_config["min_cpu_cores"]
-        latest_metrics["current_ram_mb"] = scaling_config["min_ram_mb"]
-        logging.warning(f"Using defaults for container {container_id} (config fetch failed)")
+        return
+
+    latest_metrics["current_cores"] = cores
+    latest_metrics["current_ram_mb"] = memory_mb
+    logging.debug(
+        f"Container {container_id} current config: {cores} cores, {memory_mb} MB RAM")
 
     scaling_decision, confidence = predict_anomalies(
         model, latest_metrics, features_to_use, config)

--- a/lxc_autoscale_ml/model/scaling_decisions.py
+++ b/lxc_autoscale_ml/model/scaling_decisions.py
@@ -84,6 +84,22 @@ def determine_scaling_action(latest_metrics, scaling_decision, confidence, confi
     elif ram_action == "Scale Down":
         new_ram = max(current_ram - ram_step, thresholds["min_ram_mb"])
 
+    # A container already at its floor or ceiling clamps to the value it
+    # already has. Reporting that as an action made the loop issue a no-op
+    # root `pct set` every interval and, worse, made the scaling counter and
+    # the "Successfully scaled" log meaningless -- exactly the signals an
+    # operator reaches for during an incident.
+    if new_cores is not None and new_cores == current_cores:
+        logging.debug(
+            f"CPU already at the {cpu_action.split()[-1].lower()} limit "
+            f"({current_cores} cores); no action.")
+        cpu_action, new_cores = "No Scaling", None
+    if new_ram is not None and new_ram == current_ram:
+        logging.debug(
+            f"RAM already at the {ram_action.split()[-1].lower()} limit "
+            f"({current_ram} MB); no action.")
+        ram_action, new_ram = "No Scaling", None
+
     logging.debug(f"Final scaling actions: CPU -> {cpu_action}, RAM -> {ram_action} | Confidence: {confidence}%")
     return cpu_action, ram_action, new_cores, new_ram
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -32,6 +32,16 @@ class TestGetConfigEndpoint:
     def test_all_path_and_key_combinations(self, client, pct, url):
         assert client.get(url).status_code == 200
 
+    def test_a_container_without_cores_still_answers_200(self, client, pct):
+        """`cores` is optional in Proxmox. This used to be a permanent 500,
+        which sent the scaling loop down its guess-the-allocation path."""
+        pct.output = "arch: amd64\nmemory: 2048\n"
+        response = client.get("/resource/lxc/config?lxc_id=104")
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload["data"]["cores"] is None
+        assert payload["data"]["memory_mb"] == 2048
+
     def test_missing_id_returns_structured_error(self, client, pct):
         response = client.get("/resource/lxc/config")
         assert response.status_code == 400

--- a/tests/test_lxc_management.py
+++ b/tests/test_lxc_management.py
@@ -85,15 +85,11 @@ class TestGetConfig:
     def test_get_current_resources(self, manager, pct):
         assert manager.get_current_resources(104) == (2, 2048)
 
-    def test_missing_fields_raise(self, manager, pct):
+    def test_absent_fields_are_reported_as_unknown_not_as_an_error(self, manager, pct):
+        """See TestOptionalConfigFields: `cores` is optional in Proxmox, so its
+        absence is a fact about the container rather than a failure."""
         pct.output = "arch: amd64\n"
-        with pytest.raises(RuntimeError, match="current resources"):
-            manager.get_current_resources(104)
-
-    def test_non_numeric_fields_raise(self, manager, pct):
-        pct.output = "cores: many\nmemory: 2048\n"
-        with pytest.raises(RuntimeError, match="current resources"):
-            manager.get_current_resources(104)
+        assert manager.get_current_resources(104) == (None, None)
 
 
 class TestDiskSize:
@@ -154,3 +150,24 @@ class TestCommandShapes:
         )
         manager.clone(104, 106, "web-2")
         pct.assert_ran("pct", "clone", 104, 106, "--hostname", "web-2", "--full")
+
+
+class TestOptionalConfigFields:
+    """`cores` is optional in Proxmox: `pct create` without `--cores` leaves it
+    unset, meaning "all host cores". Treating that as an error made
+    /resource/lxc/config return 500 for such a container permanently."""
+
+    def test_missing_cores_is_reported_as_unknown(self, manager, pct):
+        pct.output = "arch: amd64\nmemory: 2048\nrootfs: local-lvm:vm-104-disk-0,size=8G\n"
+        assert manager.get_current_resources(104) == (None, 2048)
+
+    def test_missing_memory_is_reported_as_unknown(self, manager, pct):
+        pct.output = "arch: amd64\ncores: 2\n"
+        assert manager.get_current_resources(104) == (2, None)
+
+    def test_non_numeric_values_are_reported_as_unknown(self, manager, pct):
+        pct.output = "cores: many\nmemory: 2048\n"
+        assert manager.get_current_resources(104) == (None, 2048)
+
+    def test_both_present_is_unchanged(self, manager, pct):
+        assert manager.get_current_resources(104) == (2, 2048)

--- a/tests/test_model_pipeline.py
+++ b/tests/test_model_pipeline.py
@@ -1,6 +1,7 @@
 """Tests for the ML side: data preparation, prediction and the scaling loop."""
 import json
 import logging
+from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
@@ -24,11 +25,19 @@ BASE_CONFIG = {
 }
 
 
-def make_snapshot(container_ids, index, **overrides):
+def make_snapshot(container_ids, index, cycles=8, **overrides):
+    """One collection cycle.
+
+    Timestamps are anchored to *now* rather than a fixed date: the model
+    refuses to scale on metrics older than `max_metrics_age_seconds`, so a
+    fixture pinned to 2026-01-01 exercises the staleness path instead of the
+    scaling path.
+    """
+    stamp = datetime.now() - timedelta(seconds=60 * (cycles - 1 - index))
     snapshot = {}
     for container_id in container_ids:
         metrics = {
-            "timestamp": f"2026-01-01T00:{index:02d}:00",
+            "timestamp": stamp.isoformat(),
             "cpu_usage_percent": 40.0 + index,
             "memory_usage_mb": 900.0 + index * 10,
             "swap_usage_mb": 0,
@@ -50,7 +59,8 @@ def make_snapshot(container_ids, index, **overrides):
 def metrics_file(tmp_path):
     def _write(container_ids=("104", "105"), cycles=8, **overrides):
         path = tmp_path / "lxc_metrics.json"
-        data = [make_snapshot(container_ids, i, **overrides) for i in range(cycles)]
+        data = [make_snapshot(container_ids, i, cycles=cycles, **overrides)
+                for i in range(cycles)]
         path.write_text(json.dumps(data))
         return str(path)
     return _write
@@ -59,10 +69,19 @@ def metrics_file(tmp_path):
 class TestLoadData:
     def test_container_ids_stay_strings(self, metrics_file):
         """The scaling loop matches on these; a silent int/str mismatch
-        matched no rows and raised IndexError on the first container."""
+        matched no rows and raised IndexError on the first container.
+
+        Asserts the contract -- the values are strings and selecting by a
+        string id matches rows -- rather than the dtype. pandas 3 gives a
+        string column `StringDtype` instead of `object`, which changes the
+        dtype without changing any behaviour this code depends on.
+        """
         df = load_data(metrics_file())
-        assert df["container_id"].dtype == object
         assert set(df["container_id"]) == {"104", "105"}
+        assert all(isinstance(v, str) for v in df["container_id"])
+        assert [str(c) for c in df["container_id"].unique()] == ["104", "105"]
+        # The selection the scaling loop performs.
+        assert not df[df["container_id"] == "104"].empty
 
     def test_summary_entry_is_skipped(self, metrics_file):
         df = load_data(metrics_file())
@@ -288,31 +307,70 @@ class TestCircuitBreakerConfig:
 
 
 class TestScalingDecisions:
+    def test_scale_up_moves_one_step(self):
+        from scaling_decisions import determine_scaling_action
+
+        metrics = pd.Series({
+            "cpu_usage_percent": 99.0, "memory_usage_mb": 15000.0,
+            "current_cores": 4, "current_ram_mb": 8192,
+        })
+        cpu_action, ram_action, new_cores, new_ram = determine_scaling_action(
+            metrics, -1, 90.0, BASE_CONFIG)
+        assert (cpu_action, new_cores) == ("Scale Up", 5)
+        assert (ram_action, new_ram) == ("Scale Up", 8704)
+
+    def test_scale_down_moves_one_step(self):
+        from scaling_decisions import determine_scaling_action
+
+        metrics = pd.Series({
+            "cpu_usage_percent": 1.0, "memory_usage_mb": 10.0,
+            "current_cores": 4, "current_ram_mb": 8192,
+        })
+        cpu_action, ram_action, new_cores, new_ram = determine_scaling_action(
+            metrics, 1, 90.0, BASE_CONFIG)
+        assert (cpu_action, new_cores) == ("Scale Down", 3)
+        assert (ram_action, new_ram) == ("Scale Down", 7680)
+
     def test_scale_up_is_capped_at_the_maximum(self):
         from scaling_decisions import determine_scaling_action
 
         metrics = pd.Series({
             "cpu_usage_percent": 99.0, "memory_usage_mb": 15000.0,
-            "current_cores": 8, "current_ram_mb": 16384,
+            "current_cores": 7, "current_ram_mb": 16000,
         })
         cpu_action, ram_action, new_cores, new_ram = determine_scaling_action(
             metrics, -1, 90.0, BASE_CONFIG)
-        assert cpu_action == "Scale Up"
         assert new_cores == BASE_CONFIG["scaling"]["max_cpu_cores"]
         assert new_ram == BASE_CONFIG["scaling"]["max_ram_mb"]
 
-    def test_scale_down_is_floored_at_the_minimum(self):
+    def test_a_container_already_at_the_ceiling_reports_no_action(self):
+        """It used to report "Scale Up" with new_cores == current_cores, so the
+        loop issued a no-op root `pct set` every interval and the scaling
+        counter stopped meaning anything."""
+        from scaling_decisions import determine_scaling_action
+
+        metrics = pd.Series({
+            "cpu_usage_percent": 99.0, "memory_usage_mb": 15000.0,
+            "current_cores": BASE_CONFIG["scaling"]["max_cpu_cores"],
+            "current_ram_mb": BASE_CONFIG["scaling"]["max_ram_mb"],
+        })
+        cpu_action, ram_action, new_cores, new_ram = determine_scaling_action(
+            metrics, -1, 90.0, BASE_CONFIG)
+        assert (cpu_action, new_cores) == ("No Scaling", None)
+        assert (ram_action, new_ram) == ("No Scaling", None)
+
+    def test_a_container_already_at_the_floor_reports_no_action(self):
         from scaling_decisions import determine_scaling_action
 
         metrics = pd.Series({
             "cpu_usage_percent": 1.0, "memory_usage_mb": 10.0,
-            "current_cores": 1, "current_ram_mb": 512,
+            "current_cores": BASE_CONFIG["scaling"]["min_cpu_cores"],
+            "current_ram_mb": BASE_CONFIG["scaling"]["min_ram_mb"],
         })
         cpu_action, ram_action, new_cores, new_ram = determine_scaling_action(
             metrics, 1, 90.0, BASE_CONFIG)
-        assert cpu_action == "Scale Down"
-        assert new_cores == BASE_CONFIG["scaling"]["min_cpu_cores"]
-        assert new_ram == BASE_CONFIG["scaling"]["min_ram_mb"]
+        assert (cpu_action, new_cores) == ("No Scaling", None)
+        assert (ram_action, new_ram) == ("No Scaling", None)
 
     def test_zero_ram_allocation_does_not_divide_by_zero(self):
         from scaling_decisions import determine_scaling_action
@@ -324,3 +382,191 @@ class TestScalingDecisions:
         cpu_action, ram_action, _, _ = determine_scaling_action(
             metrics, 1, 90.0, BASE_CONFIG)
         assert ram_action in ("Scale Up", "Scale Down", "No Scaling")
+
+
+class TestScalingDirectionEndToEnd:
+    """The regression that two repair rounds walked past.
+
+    `preprocess_data` used to standard-scale `cpu_usage_percent` and
+    `memory_usage_mb`, which `determine_scaling_action` then compared against
+    percentage thresholds. A z-score never exceeds 75 and is almost always
+    below 30, so every container was scaled DOWN on both axes every cycle: a
+    container at 99% CPU produced the same decision as one at 3%.
+
+    The existing tests asserted only that *something* was applied. These assert
+    the direction and the target value, driving the real pipeline from the
+    metrics file all the way to the call `apply_scaling` would make.
+    """
+
+    @pytest.fixture
+    def cycle(self, monkeypatch, tmp_path):
+        import lxc_autoscale_ml as orch
+
+        applied = []
+        monkeypatch.setattr(
+            orch, "apply_scaling",
+            lambda cid, cores, ram, config: applied.append((cid, cores, ram)))
+        monkeypatch.setattr(
+            orch, "fetch_container_configs_sync",
+            lambda ids, url, **kw: {cid: {"cores": 4, "memory_mb": 8192} for cid in ids})
+
+        def _run(cpu_series, mem_series, **config_overrides):
+            cycles = len(cpu_series)
+            data = []
+            for i, (cpu, mem) in enumerate(zip(cpu_series, mem_series, strict=True)):
+                snap = make_snapshot(("104",), i, cycles=cycles,
+                                     cpu_usage_percent=cpu, memory_usage_mb=mem)
+                data.append(snap)
+            path = tmp_path / "metrics.json"
+            path.write_text(json.dumps(data))
+            config = {**BASE_CONFIG, "data_file": str(path), **config_overrides}
+            applied.clear()
+            orch.run_cycle(config)
+            return list(applied)
+
+        return _run
+
+    def test_a_saturated_container_scales_up(self, cycle):
+        # 8192 MB allocated, ~7900 MB used -> 96%.
+        applied = cycle([92, 95, 97, 99, 93, 96, 98, 99],
+                        [7600, 7700, 7800, 7900, 7650, 7750, 7850, 7900])
+        assert applied == [("104", 5, 8704)], (
+            "a container at 99% CPU and 96% RAM must gain a step of each"
+        )
+
+    def test_an_idle_container_scales_down(self, cycle):
+        applied = cycle([4, 6, 5, 7, 3, 5, 6, 5],
+                        [900, 1000, 950, 1050, 880, 940, 1000, 980])
+        assert applied == [("104", 3, 7680)]
+
+    def test_a_steady_container_is_left_alone(self, cycle):
+        applied = cycle([48, 52, 50, 49, 51, 50, 52, 50],
+                        [4000, 4100, 4050, 4090, 4020, 4060, 4100, 4096])
+        assert applied == []
+
+    def test_busy_and_idle_do_not_produce_the_same_decision(self, cycle):
+        """The single clearest symptom of the inversion."""
+        busy = cycle([92, 95, 97, 99, 93, 96, 98, 99],
+                     [7600, 7700, 7800, 7900, 7650, 7750, 7850, 7900])
+        idle = cycle([4, 6, 5, 7, 3, 5, 6, 5],
+                     [900, 1000, 950, 1050, 880, 940, 1000, 980])
+        assert busy != idle, "load has no effect on the scaling decision"
+
+    def test_thresholds_see_real_units(self, metrics_file):
+        """Guards the root cause directly rather than its symptom."""
+        df = preprocess_data(load_data(metrics_file(cpu_usage_percent=99.0,
+                                                    memory_usage_mb=7900.0)),
+                             BASE_CONFIG)
+        latest = df[df["container_id"] == "104"].iloc[-1]
+        assert latest["cpu_usage_percent"] == pytest.approx(99.0), (
+            "cpu_usage_percent must reach the thresholds as a percentage, "
+            "not as a standardised score"
+        )
+        assert latest["memory_usage_mb"] == pytest.approx(7900.0)
+
+
+class TestUnknownAllocationIsNotGuessed:
+    """A failed config fetch used to substitute the configured minimum as the
+    container's *current* size, then compute an absolute target from that
+    fiction. One cycle collapsed the container to the floor, and the write was
+    self-masking because the next fetch reported the value just imposed."""
+
+    @pytest.fixture
+    def cycle(self, monkeypatch, tmp_path, metrics_file):
+        import lxc_autoscale_ml as orch
+
+        applied = []
+        monkeypatch.setattr(
+            orch, "apply_scaling",
+            lambda cid, cores, ram, config: applied.append((cid, cores, ram)))
+
+        def _run(fetch_result):
+            monkeypatch.setattr(orch, "fetch_container_configs_sync",
+                                lambda ids, url, **kw: {cid: fetch_result for cid in ids})
+            config = {**BASE_CONFIG, "data_file": metrics_file(cpu_usage_percent=99.0)}
+            applied.clear()
+            orch.run_cycle(config)
+            return list(applied)
+
+        return _run
+
+    def test_no_response_skips_the_container(self, cycle):
+        assert cycle(None) == []
+
+    def test_empty_response_skips_the_container(self, cycle):
+        assert cycle({}) == []
+
+    def test_missing_cores_skips_the_container(self, cycle):
+        """`cores` is optional in Proxmox; unset means all host cores."""
+        assert cycle({"memory_mb": 8192}) == []
+
+    def test_missing_memory_skips_the_container(self, cycle):
+        assert cycle({"cores": 4}) == []
+
+    def test_a_complete_response_is_used(self, cycle):
+        # CPU is pinned at 99% and memory sits near 970 MB of the 8192 MB
+        # allocation (~12%), so the correct answer is up on CPU, down on RAM.
+        assert cycle({"cores": 4, "memory_mb": 8192}) == [
+            ("104", 5, 7680), ("105", 5, 7680)]
+
+
+class TestStaleAndDepartedContainers:
+    @pytest.fixture
+    def orchestrator(self, monkeypatch):
+        import lxc_autoscale_ml as orch
+
+        applied = []
+        monkeypatch.setattr(
+            orch, "apply_scaling",
+            lambda cid, cores, ram, config: applied.append((cid, cores, ram)))
+        monkeypatch.setattr(
+            orch, "fetch_container_configs_sync",
+            lambda ids, url, **kw: {cid: {"cores": 4, "memory_mb": 8192} for cid in ids})
+        orch.applied = applied
+        return orch
+
+    def test_only_containers_in_the_newest_snapshot_are_evaluated(
+            self, orchestrator, tmp_path):
+        """The monitor records only running containers, but the file keeps
+        1000 cycles of history. A container stopped hours ago used to be
+        evaluated every cycle -- and with VMID reuse, a new container could be
+        scaled on its predecessor's metrics."""
+        data = [make_snapshot(("104", "105"), i, cycles=8) for i in range(6)]
+        data += [make_snapshot(("104",), i, cycles=8) for i in (6, 7)]  # 105 stopped
+        path = tmp_path / "metrics.json"
+        path.write_text(json.dumps(data))
+
+        config = {**BASE_CONFIG, "data_file": str(path)}
+        seen = []
+        real = orchestrator.evaluate_container
+        orchestrator.evaluate_container = lambda container_id, **kw: (
+            seen.append(container_id), real(container_id=container_id, **kw))[1]
+        try:
+            orchestrator.run_cycle(config)
+        finally:
+            orchestrator.evaluate_container = real
+        assert seen == ["104"], "a departed container must not be evaluated"
+
+    def test_stale_metrics_stop_the_cycle(self, orchestrator, tmp_path):
+        """A wedged monitor used to leave the model scaling on a frozen
+        snapshot forever, ratcheting every container toward a limit."""
+        old = datetime.now() - timedelta(hours=6)
+        data = []
+        for i in range(8):
+            snap = make_snapshot(("104",), i, cycles=8)
+            snap["104"]["timestamp"] = (old + timedelta(seconds=60 * i)).isoformat()
+            data.append(snap)
+        path = tmp_path / "metrics.json"
+        path.write_text(json.dumps(data))
+
+        config = {**BASE_CONFIG, "data_file": str(path)}
+        assert orchestrator.run_cycle(config) is False
+        assert orchestrator.applied == []
+
+    def test_fresh_metrics_are_accepted(self, orchestrator, tmp_path):
+        data = [make_snapshot(("104",), i, cycles=8, cpu_usage_percent=99.0)
+                for i in range(8)]
+        path = tmp_path / "metrics.json"
+        path.write_text(json.dumps(data))
+        config = {**BASE_CONFIG, "data_file": str(path)}
+        assert orchestrator.run_cycle(config) is True


### PR DESCRIPTION
Found by a 117-agent audit with adversarial verification. This is the first of
several PRs; it carries the defects that make the product do the opposite of its
purpose. **Merge this before the installer fix (#TBD)** — see sequencing below.

## The autoscaler scaled every container down, regardless of load

`preprocess_data` standard-scaled twelve columns in place. Two of them —
`cpu_usage_percent` and `memory_usage_mb` — are read by
`determine_scaling_action` and compared against percentage thresholds:

```python
cpu_usage = latest_metrics["cpu_usage_percent"]   # a z-score, roughly -3..3
if cpu_usage > thresholds["cpu_scale_up_threshold"]:      # 75  -> never
elif cpu_usage < thresholds["cpu_scale_down_threshold"]:  # 30  -> almost always
```

Measured against the real modules before the fix:

| container | real load | decision |
|---|---|---|
| busy | 99% CPU, 7900/8192 MB (96%) | **Scale Down, Scale Down** |
| idle | 3% CPU, 120 MB | **Scale Down, Scale Down** |

Identical. Every container, every cycle, to the configured floor.

The scaling was also **redundant**: `train_anomaly_models` already wraps
IsolationForest in `Pipeline([('scaler', StandardScaler()), …])` and fits it on
this same frame. Removing the in-place scaler leaves the model's inputs
unchanged and gives the thresholds real units back.

### Why two repair rounds walked past it

Every existing test asserted `applied != []` — that *something* happened, never
what. The same weakness that let a malformed `pct` command ship earlier.

`TestScalingDirectionEndToEnd` now drives `load_data → preprocess_data →
run_cycle` and asserts the target values. Reintroducing the scaler fails five
tests, including one that just asserts a busy container and an idle one do not
produce the same decision.

## Three more defects on the same destructive path

**A failed config fetch fabricated the current allocation.** Every target here
is absolute (`pct set -cores N`, not a delta) and derived from the current
allocation, so substituting `min_cpu_cores`/`min_ram_mb` did not degrade
gracefully — it wrote the container to the floor in one cycle. The write was
self-masking: the next fetch reported the value just imposed. Now it skips.

**`cores` is optional in Proxmox.** `pct create` without `--cores` leaves it
unset, meaning "all host cores". `get_current_resources` treated that as an
error, so `/resource/lxc/config` returned 500 for such a container *permanently*
— feeding it directly into the fabrication path above.

**A clamped container still emitted an action**, so the loop issued a no-op root
`pct set` every interval and the scaling counter stopped being a signal.

## Two nobody had looked at

**Departed containers were still evaluated.** The monitor records only running
containers, but the file keeps 1000 cycles of history and the loop took
`unique()` over all of it. A container stopped hours ago was evaluated every
cycle — and because Proxmox reuses VMIDs, a *new* container could be scaled on
its predecessor's metrics for up to 16 hours.

**Nothing checked metric freshness.** A wedged monitor left the model scaling on
a frozen snapshot forever while the live allocation ratcheted toward a limit.

## Sequencing — please read

A fresh `curl … | bash` install currently cannot run the model at all, because
`install.sh` never installs `aiohttp`. That broken installer is the only thing
preventing the inversion above from shrinking every container on the node.
**Fixing the installer before this lands converts a dead service into an
actively destructive one.**

## Verification

- 225 tests pass on Python 3.11, 3.12 and 3.13
- passes against both the currently pinned dependencies **and** the
  numpy 2.4.6 / pandas 3.0.5 / scikit-learn 1.9.0 stack
- `ruff` clean
- reintroducing the scaler fails 5 tests; reintroducing the fabrication fails 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
