### PR TITLE
fix(security): close the CSRF vector, and make authentication usable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -116,6 +116,8 @@ install_lxc_autoscale_ml() {
 
     # Create necessary directories
     mkdir -p /etc/lxc_autoscale_ml /usr/local/bin/lxc_autoscale_api /usr/local/bin/lxc_autoscale_ml
+    # The configs below carry API keys.
+    chmod 0750 /etc/lxc_autoscale_ml
 
     # Clone the repository
     REPO_URL="https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml.git"
@@ -153,11 +155,16 @@ install_config() {
     name=$(basename "$source_file")
     local target="/etc/lxc_autoscale_ml/${name}"
 
+    # 0600: lxc_autoscale_api.yaml holds authentication.api_keys, and the
+    # model config holds the matching api.api_key. They were installed
+    # world-readable into a world-readable directory.
     if [[ -e "$target" ]]; then
-        mv "$source_file" "${target}.new"
+        install -m 0600 -o root -g root "$source_file" "${target}.new"
+        rm -f "$source_file"
         log "WARNING" "${target} already exists; shipped defaults written to ${target}.new" "$WARNING"
     else
-        mv "$source_file" "$target"
+        install -m 0600 -o root -g root "$source_file" "$target"
+        rm -f "$source_file"
         log "SUCCESS" "Installed ${target}" "$CHECKMARK"
     fi
 }

--- a/lxc_autoscale_ml/api/authentication.py
+++ b/lxc_autoscale_ml/api/authentication.py
@@ -21,7 +21,8 @@ def require_api_key(f):
     """
     Decorator to require API key authentication.
 
-    Expects API key in X-API-Key header or api_key query parameter.
+    Expects the API key in the X-API-Key header. The query parameter form was
+    removed: it leaked the key into access logs.
     Configure API keys in lxc_autoscale_api.yaml under 'api_keys' section.
 
     Example config:
@@ -38,13 +39,14 @@ def require_api_key(f):
         if not auth_config.get('enabled', False):
             return f(*args, **kwargs)
 
-        # Get API key from header or query param
-        api_key = request.headers.get('X-API-Key') or request.args.get('api_key')
+        # Header only. Accepting ?api_key= put the secret in the gunicorn
+        # access log, in shell history, and in any proxy log in front of it.
+        api_key = request.headers.get('X-API-Key')
 
         if not api_key:
             return jsonify({
                 "status": "error",
-                "message": "Missing API key. Provide via X-API-Key header or api_key parameter."
+                "message": "Missing API key. Provide it in the X-API-Key header."
             }), 401
 
         # Verify API key
@@ -56,8 +58,18 @@ def require_api_key(f):
                 "message": "API authentication misconfigured"
             }), 500
 
-        # Simple constant-time comparison
-        key_valid = any(hmac.compare_digest(api_key, valid_key) for valid_key in valid_keys)
+        # Constant-time comparison. compare_digest raises TypeError on a
+        # non-ASCII str, so a configured key containing e.g. a curly quote made
+        # EVERY request fail with a 500 and a traceback that never named the
+        # key. Compare bytes instead.
+        try:
+            provided = api_key.encode("utf-8")
+            key_valid = any(
+                hmac.compare_digest(provided, str(valid_key).encode("utf-8"))
+                for valid_key in valid_keys
+            )
+        except (AttributeError, UnicodeError):
+            key_valid = False
 
         if not key_valid:
             current_app.logger.warning(f"Invalid API key attempt from {request.remote_addr}")

--- a/lxc_autoscale_ml/api/gunicorn_config.py
+++ b/lxc_autoscale_ml/api/gunicorn_config.py
@@ -60,9 +60,22 @@ timeout = _gunicorn.get("timeout_seconds", 120)
 graceful_timeout = _gunicorn.get("graceful_timeout_seconds", 30)
 preload_app = _gunicorn.get("preload_app", True)
 
-# Recycle workers periodically as a backstop against slow leaks.
-max_requests = _gunicorn.get("max_requests", 500)
-max_requests_jitter = _gunicorn.get("max_requests_jitter", 50)
+# Worker recycling is OFF by default, and that is deliberate.
+#
+# The rate limiter's per-IP window and the Prometheus counters live in this
+# process's memory. gthread counts a request before handing it to the app, so
+# 429s and 401s drove the recycle themselves -- an attacker's own rejected
+# requests cleared the window that was throttling them. The unbounded-memory
+# argument for recycling no longer applies either: rate_limiting evicts idle
+# clients and caps the table.
+max_requests = _gunicorn.get("max_requests", 0)
+max_requests_jitter = _gunicorn.get("max_requests_jitter", 0)
+
+# Do not log the query string: `?api_key=` is an accepted way to authenticate,
+# and gunicorn's default access format ("%(r)s") writes the full request line,
+# putting the key in a world-readable log file.
+access_log_format = _gunicorn.get(
+    "access_log_format", '%(h)s "%(m)s %(U)s %(H)s" %(s)s %(b)s %(D)sus')
 
 loglevel = _gunicorn.get("log_level", "info")
 accesslog = _gunicorn.get("access_log_file", "-")

--- a/lxc_autoscale_ml/api/health_check.py
+++ b/lxc_autoscale_ml/api/health_check.py
@@ -8,11 +8,34 @@ whatever is watching it.
 import logging
 import shutil
 import subprocess
+import threading
+import time
 
 from flask import current_app, jsonify
 
 # The health check must answer quickly even when the node is struggling.
 PROBE_TIMEOUT_SECONDS = 5
+
+# The probe forks `pct list` as root. The endpoint is deliberately
+# unauthenticated so systemd and Prometheus can reach it, which means anyone
+# who can reach the port can make the API fork. Caching bounds that to one fork
+# per interval regardless of request rate.
+PROBE_CACHE_SECONDS = 5
+_probe_cache = {"at": 0.0, "result": None}
+_probe_lock = threading.Lock()
+
+
+def _cached_check_pct():
+    now = time.monotonic()
+    with _probe_lock:
+        cached = _probe_cache["result"]
+        if cached is not None and now - _probe_cache["at"] < PROBE_CACHE_SECONDS:
+            return cached
+    result = _check_pct()
+    with _probe_lock:
+        _probe_cache["at"] = time.monotonic()
+        _probe_cache["result"] = result
+    return result
 
 
 def _check_pct():
@@ -42,7 +65,7 @@ def health_check():
     checks = {}
     healthy = True
 
-    pct_ok, pct_detail = _check_pct()
+    pct_ok, pct_detail = _cached_check_pct()
     checks["lxc_commands"] = {"ok": pct_ok, "detail": pct_detail}
     healthy = healthy and pct_ok
 

--- a/lxc_autoscale_ml/api/lxc_autoscale_api.py
+++ b/lxc_autoscale_ml/api/lxc_autoscale_api.py
@@ -71,6 +71,9 @@ ENDPOINTS = [
 ]
 
 
+KNOWN_METHODS = frozenset({'GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'})
+
+
 def _escape(text):
     """Minimal HTML escaping for the self-documenting home page."""
     return (
@@ -335,6 +338,7 @@ def check_cluster_status_route():
 # --- Operations --------------------------------------------------------------
 
 @app.route('/health/check', methods=['GET'])
+@rate_limit
 def health_check_route():
     logging.info("Health check endpoint accessed")
     return health_check()
@@ -346,6 +350,7 @@ def metrics_route():
 
 
 @app.route('/routes', methods=['GET'])
+@rate_limit
 @require_api_key
 def list_routes():
     routes = []
@@ -370,9 +375,13 @@ def _start_timer():
 def _record_request_metrics(response):
     start_time = getattr(request, 'start_time', None)
     duration = None if start_time is None else time.monotonic() - start_time
-    # Use the matched rule rather than the raw path so metric cardinality stays bounded.
+    # Both labels are clamped. The endpoint uses the matched rule rather than
+    # the raw path; the method is checked against the known verbs, because an
+    # unmatched route never reaches @rate_limit (it is a per-view decorator) so
+    # a client could mint an unbounded number of series at line rate.
     endpoint = request.url_rule.rule if request.url_rule is not None else 'unmatched'
-    record_api_request(request.method, endpoint, response.status_code, duration)
+    method = request.method if request.method in KNOWN_METHODS else 'other'
+    record_api_request(method, endpoint, response.status_code, duration)
     return response
 
 

--- a/lxc_autoscale_ml/api/lxc_autoscale_api.yaml
+++ b/lxc_autoscale_ml/api/lxc_autoscale_api.yaml
@@ -115,8 +115,17 @@ gunicorn:
   # Time to wait before forcefully killing workers during a graceful restart.
   graceful_timeout_seconds: 30  
   
-  # Number of requests a worker will handle before being restarted. Helps to prevent memory leaks.
-  max_requests: 500  
-  
-  # Adds a random jitter to `max_requests` to avoid all workers restarting at the same time.
-  max_requests_jitter: 50  
+  # Requests a worker handles before being recycled. 0 disables it, which is
+  # the default and is deliberate: the rate-limiter window and the Prometheus
+  # counters live in worker memory, so recycling silently resets both -- and a
+  # client's own rejected requests drove the recycle that cleared its window.
+  # The limiter evicts idle clients itself, so recycling is not needed to bound
+  # memory.
+  max_requests: 0
+
+  # Random spread on max_requests. Irrelevant while max_requests is 0.
+  max_requests_jitter: 0
+
+  # Access log format. Deliberately omits the query string, because ?api_key=
+  # is an accepted authentication method and this file is world-readable.
+  access_log_format: '%(h)s "%(m)s %(U)s %(H)s" %(s)s %(b)s %(D)sus'

--- a/lxc_autoscale_ml/api/rate_limiting.py
+++ b/lxc_autoscale_ml/api/rate_limiting.py
@@ -1,12 +1,35 @@
 from functools import wraps
-from flask import request, jsonify, current_app
+from flask import current_app, jsonify, make_response, request
 import time
 import threading
 
-# Simple in-memory rate limiting for demonstration purposes
+# Per-IP sliding windows. Entries are evicted once their newest timestamp
+# ages out: pruning only the bucket of the IP currently being served meant a
+# scan of distinct source addresses grew this dictionary without bound, since
+# an address that never returns is never looked at again.
 rate_limit_data = {}
+
+# Hard ceiling, in case eviction cannot keep up with a wide enough scan.
+MAX_TRACKED_CLIENTS = 10000
 # Lock to ensure thread-safe access to the shared rate_limit_data dictionary
 _rate_limit_lock = threading.Lock()
+
+def _evict_idle_clients(current_time, time_window):
+    """Forget clients whose whole window has expired.
+
+    Must be called with the lock held.
+    """
+    stale = [ip for ip, times in rate_limit_data.items()
+             if not times or current_time - times[-1] >= time_window]
+    for ip in stale:
+        del rate_limit_data[ip]
+
+    if len(rate_limit_data) > MAX_TRACKED_CLIENTS:
+        # Drop the least recently seen first.
+        for ip in sorted(rate_limit_data, key=lambda i: rate_limit_data[i][-1])[
+                :len(rate_limit_data) - MAX_TRACKED_CLIENTS]:
+            del rate_limit_data[ip]
+
 
 def rate_limit(f):
     """
@@ -41,6 +64,8 @@ def rate_limit(f):
         # lock: scaling calls shell out to `pct` and can take seconds, and
         # holding the lock across them would serialise the whole API.
         with _rate_limit_lock:
+            _evict_idle_clients(current_time, time_window)
+
             # Drop access times that fell out of the sliding window
             access_times = [
                 t for t in rate_limit_data.get(client_ip, [])
@@ -58,6 +83,7 @@ def rate_limit(f):
                 limited = None
 
             remaining = max(0, max_requests - len(access_times))
+            reset_at = (min(access_times) if access_times else current_time) + time_window
 
         if limited is not None:
             retry_after, oldest_request = limited
@@ -74,11 +100,13 @@ def rate_limit(f):
             response.headers['X-RateLimit-Reset'] = str(int(oldest_request + time_window))
             return response, 429
 
-        response = f(*args, **kwargs)
-        if hasattr(response, 'headers'):
-            response.headers['X-RateLimit-Limit'] = str(max_requests)
-            response.headers['X-RateLimit-Remaining'] = str(remaining)
-
+        # Every rate-limited view returns Flask's (body, status) tuple, which
+        # has no `.headers`, so the documented X-RateLimit-* headers were never
+        # emitted on a successful response. Normalise first.
+        response = make_response(f(*args, **kwargs))
+        response.headers['X-RateLimit-Limit'] = str(max_requests)
+        response.headers['X-RateLimit-Remaining'] = str(remaining)
+        response.headers['X-RateLimit-Reset'] = str(int(reset_at))
         return response
 
     return decorated_function

--- a/lxc_autoscale_ml/api/validation.py
+++ b/lxc_autoscale_ml/api/validation.py
@@ -120,11 +120,14 @@ def validate_snapshot_name(snapshot_name):
     if not snapshot_name or not isinstance(snapshot_name, str):
         raise ValidationError("Snapshot name must be a non-empty string")
 
-    # Allow alphanumeric, hyphens, underscores, max 40 chars
-    if not re.match(r'^[a-zA-Z0-9_-]{1,40}$', snapshot_name):
+    # Alphanumeric, hyphens and underscores, max 40 chars, and it may not
+    # START with a hyphen: `pct delsnapshot 104 -foo` would read the name as an
+    # option rather than as an argument.
+    if not re.match(r'^[a-zA-Z0-9_][a-zA-Z0-9_-]{0,39}$', snapshot_name):
         raise ValidationError(
-            f"Snapshot name must contain only alphanumeric characters, "
-            f"hyphens, and underscores (max 40 chars): {snapshot_name}"
+            f"Snapshot name must start with a letter, digit or underscore and "
+            f"contain only alphanumeric characters, hyphens and underscores "
+            f"(max 40 chars): {snapshot_name}"
         )
 
     return snapshot_name
@@ -183,19 +186,33 @@ def validate_node_name(node_name):
 
     return node_name
 
+# Methods that do not change state. Only these may take their parameters from
+# the query string.
+SAFE_METHODS = frozenset({"GET", "HEAD"})
+
+
 def extract_request_data():
     """
-    Collect request parameters from the query string and the JSON body.
+    Collect request parameters for the current request.
 
     ``request.get_json(silent=True)`` returns ``None`` instead of aborting the
     request when there is no body or the Content-Type is not JSON, which is the
     normal situation for a GET. Reading ``request.json`` directly there raises
     and Flask turns that into a 400/415 before the view ever runs.
 
+    The query string is read **only for safe methods**. Accepting it on every
+    method made the mutating endpoints drivable by a cross-origin HTML form:
+    a `<form method="post" action="http://host:5000/scale/ram?lxc_id=104&memory=64">`
+    is a CORS *simple request*, so it needs no preflight and no JSON content
+    type. With authentication disabled and the API bound to 0.0.0.0 -- both
+    shipped defaults -- any page an operator loaded could resize or roll back
+    containers on a root-privileged API. Requiring a JSON body for mutating
+    methods restores the preflight that blocks it.
+
     Returns:
         dict: Merged parameters, with JSON body values taking precedence.
     """
-    data = request.args.to_dict()
+    data = request.args.to_dict() if request.method in SAFE_METHODS else {}
 
     payload = request.get_json(silent=True)
     if isinstance(payload, dict):

--- a/lxc_autoscale_ml/model/async_api_client.py
+++ b/lxc_autoscale_ml/model/async_api_client.py
@@ -15,7 +15,8 @@ class AsyncAPIClient:
     - Timeout management
     """
 
-    def __init__(self, base_url: str, timeout: int = 5, max_concurrent: int = 10):
+    def __init__(self, base_url: str, timeout: int = 5, max_concurrent: int = 10,
+                 api_key: str | None = None):
         """
         Initialize async API client.
 
@@ -23,8 +24,11 @@ class AsyncAPIClient:
             base_url: Base URL for API (e.g., http://127.0.0.1:5000)
             timeout: Request timeout in seconds
             max_concurrent: Maximum concurrent requests
+            api_key: Sent as X-API-Key. Required when the API has
+                `authentication.enabled: true`; without it every request 401s.
         """
         self.base_url = base_url.rstrip('/')
+        self.api_key = api_key
         self.timeout = aiohttp.ClientTimeout(total=timeout)
         self.max_concurrent = max_concurrent
         self.semaphore = asyncio.Semaphore(max_concurrent)
@@ -39,7 +43,8 @@ class AsyncAPIClient:
         )
         self._session = aiohttp.ClientSession(
             connector=connector,
-            timeout=self.timeout
+            timeout=self.timeout,
+            headers={"X-API-Key": self.api_key} if self.api_key else None,
         )
         return self
 
@@ -105,6 +110,16 @@ class AsyncAPIClient:
                                 if circuit_breaker:
                                     circuit_breaker.record_failure(f"api_{container_id}")
                                 return (container_id, None)
+                        elif response.status in (401, 403):
+                            # Retrying cannot help, and the generic "client
+                            # error" wording sent operators looking in the
+                            # wrong place while autoscaling silently stopped.
+                            logging.error(
+                                f"The API rejected our credentials (HTTP {response.status}). "
+                                f"It has authentication.enabled: true; set `api.api_key` in "
+                                f"the model configuration to one of its `authentication.api_keys`."
+                            )
+                            return (container_id, None)
                         else:
                             # Client error - don't retry
                             logging.warning(
@@ -197,7 +212,8 @@ async def fetch_all_container_configs(
     api_url: str,
     circuit_breaker = None,
     timeout: int = 5,
-    max_concurrent: int = 10
+    max_concurrent: int = 10,
+    api_key: str | None = None,
 ) -> dict[str, dict | None]:
     """
     Convenience function to fetch all container configs with proper session management.
@@ -212,7 +228,7 @@ async def fetch_all_container_configs(
     Returns:
         Dict mapping container_id to config
     """
-    async with AsyncAPIClient(api_url, timeout, max_concurrent) as client:
+    async with AsyncAPIClient(api_url, timeout, max_concurrent, api_key) as client:
         return await client.fetch_batch_configs(container_ids, circuit_breaker)
 
 
@@ -221,7 +237,8 @@ def fetch_container_configs_sync(
     api_url: str,
     circuit_breaker = None,
     timeout: int = 5,
-    max_concurrent: int = 10
+    max_concurrent: int = 10,
+    api_key: str | None = None,
 ) -> dict[str, dict | None]:
     """
     Synchronous wrapper for async batch fetch - for use in sync code.
@@ -246,7 +263,7 @@ def fetch_container_configs_sync(
                 future = executor.submit(
                     asyncio.run,
                     fetch_all_container_configs(
-                        container_ids, api_url, circuit_breaker, timeout, max_concurrent
+                        container_ids, api_url, circuit_breaker, timeout, max_concurrent, api_key
                     )
                 )
                 return future.result()
@@ -254,13 +271,13 @@ def fetch_container_configs_sync(
             # Use existing loop
             return loop.run_until_complete(
                 fetch_all_container_configs(
-                    container_ids, api_url, circuit_breaker, timeout, max_concurrent
+                    container_ids, api_url, circuit_breaker, timeout, max_concurrent, api_key
                 )
             )
     except RuntimeError:
         # No event loop, create new one
         return asyncio.run(
             fetch_all_container_configs(
-                container_ids, api_url, circuit_breaker, timeout, max_concurrent
+                container_ids, api_url, circuit_breaker, timeout, max_concurrent, api_key
             )
         )

--- a/lxc_autoscale_ml/model/lxc_autoscale_ml.py
+++ b/lxc_autoscale_ml/model/lxc_autoscale_ml.py
@@ -194,6 +194,7 @@ def run_cycle(config, circuit_breaker=None):
         # older documentation.
         timeout=api_config.get("timeout_seconds", api_config.get("timeout", 5)),
         max_concurrent=api_config.get("max_concurrent", 10),
+        api_key=api_config.get("api_key"),
     )
 
     batch_duration = time.monotonic() - batch_start

--- a/lxc_autoscale_ml/model/lxc_autoscale_ml.yaml
+++ b/lxc_autoscale_ml/model/lxc_autoscale_ml.yaml
@@ -64,6 +64,11 @@ api:
   cores_endpoint: "/scale/cores"  # Endpoint for scaling CPU cores
   ram_endpoint: "/scale/ram"  # Endpoint for scaling RAM
   timeout_seconds: 5  # Per-request timeout when talking to the API
+
+  # API key, sent as X-API-Key. REQUIRED if the API has
+  # authentication.enabled: true -- without it every request is rejected with
+  # 401 and autoscaling stops. Must match one of the API's authentication.api_keys.
+  # api_key: "your-secret-api-key-here"
   max_concurrent: 10  # Maximum parallel config fetches
 
 # Retry Logic for API Calls

--- a/lxc_autoscale_ml/model/scaling_decisions.py
+++ b/lxc_autoscale_ml/model/scaling_decisions.py
@@ -131,12 +131,15 @@ def apply_scaling(lxc_id, new_cores, new_ram, config):
     # `timeout` is accepted as well for configs written against the older
     # documentation.
     request_timeout = config["api"].get("timeout_seconds", config["api"].get("timeout", 10))
+    api_key = config["api"].get("api_key")
+    headers = {"X-API-Key": api_key} if api_key else None
 
     def perform_request(url, data, resource_type):
         resource_key = "cores" if resource_type == "CPU" else "memory"
         for attempt in range(max_retries):
             try:
-                response = requests.post(url, json=data, timeout=request_timeout)
+                response = requests.post(url, json=data, timeout=request_timeout,
+                                         headers=headers)
                 response.raise_for_status()
                 logging.info(f"Successfully scaled {resource_type} for LXC ID {lxc_id} to {data[resource_key]} {resource_type} units.")
                 return True
@@ -145,6 +148,17 @@ def apply_scaling(lxc_id, new_cores, new_ram, config):
                 # response was ever received. Reading it off the local variable
                 # instead used to raise UnboundLocalError and mask the failure.
                 status_code = e.response.status_code if e.response is not None else None
+                if status_code in (401, 403):
+                    # Retrying cannot help. Without this the operator saw only
+                    # a generic failure while autoscaling stopped, and the
+                    # usual response was to turn authentication back off.
+                    logging.error(
+                        f"The API rejected our credentials (HTTP {status_code}) when scaling "
+                        f"{resource_type} for LXC ID {lxc_id}. It has authentication.enabled: "
+                        f"true; set `api.api_key` in the model configuration to one of its "
+                        f"`authentication.api_keys`."
+                    )
+                    return False
                 if status_code == 500:
                     logging.error(f"Server error (500) encountered on attempt {attempt + 1} to scale {resource_type} for LXC ID {lxc_id}. Aborting further attempts.")
                     break  # Skip further retries for 500 errors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,12 +47,24 @@ def app(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def reset_rate_limit():
+def reset_module_state():
+    """Clear every piece of process-global state between tests.
+
+    The API keeps the rate-limit windows and the health probe's cache in module
+    memory. Leaking either across tests makes results depend on execution
+    order, which is how a cached "healthy" made a later unhealthy assertion
+    pass for the wrong reason.
+    """
+    import health_check
     import rate_limiting
 
-    rate_limiting.rate_limit_data.clear()
+    def clear():
+        rate_limiting.rate_limit_data.clear()
+        health_check._probe_cache.update({"at": 0.0, "result": None})
+
+    clear()
     yield
-    rate_limiting.rate_limit_data.clear()
+    clear()
 
 
 @pytest.fixture

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,234 @@
+"""Security properties of the API.
+
+Everything here protects a daemon that runs as root on a Proxmox hypervisor and
+executes `pct`. Each test names the exposure it closes.
+"""
+
+import pytest
+
+REMOTE = {"REMOTE_ADDR": "192.168.1.50"}
+
+MUTATING_ROUTES = [
+    ("POST", "/scale/cores", {"lxc_id": 104, "cores": 1}),
+    ("POST", "/scale/ram", {"lxc_id": 104, "memory": 64}),
+    ("POST", "/scale/storage/increase", {"lxc_id": 104, "disk_size": 1}),
+    ("POST", "/snapshot/create", {"lxc_id": 104, "snapshot_name": "x"}),
+    ("POST", "/snapshot/rollback", {"lxc_id": 104, "snapshot_name": "x"}),
+    ("POST", "/clone/create", {"lxc_id": 104, "new_lxc_id": 105, "new_lxc_name": "c"}),
+    ("DELETE", "/clone/delete", {"lxc_id": 105}),
+]
+
+
+class TestCrossSiteRequestForgery:
+    """A cross-origin `<form method=post>` is a CORS *simple request*: no
+    preflight, no JSON content type. While the parameters could come from the
+    query string, any page an operator loaded could resize or destroy
+    containers on an API that ships unauthenticated and bound to 0.0.0.0.
+    """
+
+    @pytest.mark.parametrize("method,path,params", MUTATING_ROUTES,
+                             ids=[r[1] for r in MUTATING_ROUTES])
+    def test_query_string_cannot_drive_a_mutating_route(self, client, pct, method, path, params):
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        response = client.open(f"{path}?{query}", method=method,
+                               content_type="application/x-www-form-urlencoded",
+                               data="", environ_overrides=REMOTE)
+        assert response.status_code == 400, f"{method} {path} accepted query-string parameters"
+        assert pct == [], f"{method} {path} executed a command: {pct.commands}"
+
+    @pytest.mark.parametrize("method,path,params", MUTATING_ROUTES,
+                             ids=[r[1] for r in MUTATING_ROUTES])
+    def test_a_json_body_still_works(self, client, pct, method, path, params):
+        response = client.open(path, method=method, json=params)
+        assert response.status_code == 200, f"{method} {path} rejected a legitimate JSON body"
+
+    def test_get_routes_still_accept_the_query_string(self, client, pct):
+        """Issue #14: the whole point of reading the query string was GETs."""
+        for url in ("/resource/lxc/config?lxc_id=104",
+                    "/resource/lxc/status?lxc_id=104",
+                    "/snapshot/list?lxc_id=104"):
+            assert client.get(url).status_code == 200, url
+
+
+class TestRouteProtection:
+    """A table of what every route requires, so that deleting a decorator or
+    adding an unprotected route fails CI. Authentication and rate limiting were
+    previously exercised on exactly one route between them."""
+
+    # route -> (requires_api_key, rate_limited)
+    EXPECTED = {
+        "/": (False, False),
+        "/health/check": (False, True),
+        "/metrics": (False, False),
+        "/routes": (True, True),
+        "/scale/cores": (True, True),
+        "/scale/ram": (True, True),
+        "/scale/storage/increase": (True, True),
+        "/snapshot/create": (True, True),
+        "/snapshot/list": (True, True),
+        "/snapshot/rollback": (True, True),
+        "/clone/create": (True, True),
+        "/clone/delete": (True, True),
+        "/resource/lxc/status": (True, True),
+        "/resource/vm/status": (True, True),
+        "/resource/lxc/config": (True, True),
+        "/resource/vm/config": (True, True),
+        "/resource/node/status": (True, True),
+        "/resource/cluster/status": (True, True),
+    }
+
+    def test_every_route_has_a_declared_expectation(self, app):
+        actual = {str(r) for r in app.url_map.iter_rules()
+                  if not str(r).startswith("/static")}
+        assert actual == set(self.EXPECTED), (
+            "a route was added or removed without declaring its protection here"
+        )
+
+    @pytest.mark.parametrize("route", sorted(r for r, (_, limited) in EXPECTED.items() if limited))
+    def test_declared_rate_limiting_is_actually_applied(self, app, client, pct, route):
+        """Behavioural, not introspective: @wraps hides the decorator names, and
+        what matters is that a remote caller is actually throttled."""
+        rule = next(r for r in app.url_map.iter_rules() if str(r) == route)
+        method = next(m for m in rule.methods if m not in ("HEAD", "OPTIONS"))
+        remote = {"REMOTE_ADDR": "10.9.9.9"}
+        codes = [client.open(route, method=method, json={}, environ_overrides=remote).status_code
+                 for _ in range(5)]
+        assert 429 in codes, f"{route} is not rate limited (saw {codes})"
+
+    @pytest.mark.parametrize("route", sorted(r for r, (_, limited) in EXPECTED.items() if not limited))
+    def test_unlimited_routes_stay_unlimited(self, app, client, pct, route):
+        remote = {"REMOTE_ADDR": "10.9.9.8"}
+        codes = [client.get(route, environ_overrides=remote).status_code for _ in range(5)]
+        assert 429 not in codes, f"{route} unexpectedly throttled"
+
+    @pytest.mark.parametrize("route", sorted(r for r, (a, _) in EXPECTED.items() if a))
+    def test_protected_routes_reject_an_anonymous_caller(self, app, client, pct, route):
+        """Behavioural check, independent of how the decorators are spelled."""
+        app.config["AUTHENTICATION"] = {"enabled": True, "api_keys": ["s3cret"]}
+        rule = next(r for r in app.url_map.iter_rules() if str(r) == route)
+        method = next(m for m in rule.methods if m not in ("HEAD", "OPTIONS"))
+        response = client.open(route, method=method, json={})
+        assert response.status_code == 401, f"{route} served an anonymous caller"
+        assert pct == []
+
+
+class TestApiKeyHandling:
+    def test_the_key_is_not_accepted_in_the_query_string(self, app, client, pct):
+        """It used to be, which wrote the secret into the gunicorn access log,
+        shell history and any intermediate proxy log."""
+        app.config["AUTHENTICATION"] = {"enabled": True, "api_keys": ["s3cret"]}
+        assert client.get("/resource/lxc/status?lxc_id=104&api_key=s3cret").status_code == 401
+
+    def test_the_header_is_accepted(self, app, client, pct):
+        app.config["AUTHENTICATION"] = {"enabled": True, "api_keys": ["s3cret"]}
+        response = client.get("/resource/lxc/status?lxc_id=104",
+                              headers={"X-API-Key": "s3cret"})
+        assert response.status_code == 200
+
+    def test_a_non_ascii_key_is_rejected_not_a_500(self, app, client, pct):
+        """hmac.compare_digest raises TypeError on a non-ASCII str, so a
+        configured key with a curly quote made every request 500."""
+        app.config["AUTHENTICATION"] = {"enabled": True, "api_keys": ["s3cret’"]}
+        response = client.get("/resource/lxc/status?lxc_id=104",
+                              headers={"X-API-Key": "wrong"})
+        assert response.status_code == 403
+
+    def test_a_matching_non_ascii_key_still_authenticates(self, app, client, pct):
+        app.config["AUTHENTICATION"] = {"enabled": True, "api_keys": ["s3cret’"]}
+        response = client.get("/resource/lxc/status?lxc_id=104",
+                              headers={"X-API-Key": "s3cret’"})
+        assert response.status_code == 200
+
+
+class TestArgumentInjection:
+    @pytest.mark.parametrize("name", ["-f", "--force", "-rf"])
+    def test_a_snapshot_name_cannot_start_a_pct_option(self, client, pct, name):
+        """`pct delsnapshot 104 -foo` reads the name as an option."""
+        response = client.post("/snapshot/create",
+                               json={"lxc_id": 104, "snapshot_name": name})
+        assert response.status_code == 400
+        assert pct == []
+
+    @pytest.mark.parametrize("name", ["backup-1", "b_2", "Snap9"])
+    def test_ordinary_names_are_still_accepted(self, client, pct, name):
+        assert client.post("/snapshot/create",
+                           json={"lxc_id": 104, "snapshot_name": name}).status_code == 200
+
+
+class TestRateLimiterState:
+    def test_idle_clients_are_evicted(self, client, pct, monkeypatch):
+        """The window was pruned only for the IP being served, so a scan of
+        source addresses grew the table without bound."""
+        import rate_limiting
+
+        clock = [1000.0]
+        monkeypatch.setattr(rate_limiting.time, "time", lambda: clock[0])
+        for i in range(50):
+            client.get("/resource/lxc/status?lxc_id=104",
+                       environ_overrides={"REMOTE_ADDR": f"10.0.0.{i}"})
+        assert len(rate_limiting.rate_limit_data) == 50
+
+        clock[0] += 3600  # every window has expired
+        client.get("/resource/lxc/status?lxc_id=104",
+                   environ_overrides={"REMOTE_ADDR": "10.0.1.1"})
+        assert len(rate_limiting.rate_limit_data) == 1
+
+    def test_the_table_is_capped(self, client, pct, monkeypatch):
+        import rate_limiting
+
+        monkeypatch.setattr(rate_limiting, "MAX_TRACKED_CLIENTS", 10)
+        for i in range(40):
+            client.get("/resource/lxc/status?lxc_id=104",
+                       environ_overrides={"REMOTE_ADDR": f"10.1.{i // 256}.{i % 256}"})
+        assert len(rate_limiting.rate_limit_data) <= 11
+
+    def test_rate_limit_headers_are_emitted_on_success(self, client, pct):
+        """Every rate-limited view returns Flask's (body, status) tuple, which
+        has no `.headers`, so the documented headers were unreachable."""
+        response = client.get("/resource/lxc/status?lxc_id=104",
+                              environ_overrides={"REMOTE_ADDR": "10.2.0.1"})
+        assert response.status_code == 200
+        assert response.headers["X-RateLimit-Limit"] == "3"
+        assert response.headers["X-RateLimit-Remaining"] == "2"
+        assert int(response.headers["X-RateLimit-Reset"]) > 0
+
+    def test_remaining_counts_down(self, client, pct):
+        remote = {"REMOTE_ADDR": "10.2.0.2"}
+        seen = [client.get("/resource/lxc/status?lxc_id=104", environ_overrides=remote)
+                .headers["X-RateLimit-Remaining"] for _ in range(3)]
+        assert seen == ["2", "1", "0"]
+
+
+class TestHealthCheckExposure:
+    def test_the_probe_is_cached(self, client, monkeypatch):
+        """The endpoint is deliberately anonymous, so an unauthenticated caller
+        could make the API fork a root `pct list` per request."""
+        import health_check
+
+        calls = []
+        monkeypatch.setattr(health_check, "_check_pct",
+                            lambda: (calls.append(1), (True, "ok"))[1])
+        for _ in range(20):
+            client.get("/health/check")
+        assert len(calls) == 1
+
+    def test_it_is_rate_limited_for_remote_callers(self, client, monkeypatch):
+        import health_check
+
+        monkeypatch.setattr(health_check, "_check_pct", lambda: (True, "ok"))
+        codes = [client.get("/health/check", environ_overrides={"REMOTE_ADDR": "10.3.0.1"})
+                 .status_code for _ in range(5)]
+        assert 429 in codes
+
+
+class TestMetricLabels:
+    def test_an_unknown_method_does_not_mint_a_new_series(self, client, pct):
+        """An unmatched route never reaches @rate_limit, so the method label
+        was attacker-controlled at line rate."""
+        metrics = pytest.importorskip("metrics")
+        if not metrics.PROMETHEUS_AVAILABLE:
+            pytest.skip("prometheus_client is not installed")
+        client.open("/no/such/route", method="PROPFIND")
+        body = client.get("/metrics").get_data(as_text=True)
+        assert "PROPFIND" not in body
+        assert 'method="other"' in body


### PR DESCRIPTION
Stacked on #41 — review that first, and merge it first.

Found by the same 117-agent audit. Everything here protects a daemon that runs
**as root on a Proxmox hypervisor** and executes `pct`.

## A cross-origin form could drive `pct` — and I introduced it

`extract_request_data` merged `request.args` on *every* HTTP method. Before the
issue-#14 repair, a form-style POST hit `request.json` and got a 415, so it
could not reach the handler. Afterwards, the six mutating POST routes became
drivable by:

```html
<form method="post" action="http://proxmox:5000/scale/ram?lxc_id=104&memory=64">
```

That is a CORS **simple request**: no preflight, no JSON content type, no token,
and — with the shipped `authentication.enabled: false` and
`server.host: 0.0.0.0` — no credential. Any page an operator loaded could shrink
or roll back containers.

Reproduced before the fix; after it:

| request | before | after |
|---|---|---|
| cross-origin form POST, query string | `200`, `pct set` ran | `400`, nothing ran |
| `DELETE /clone/delete?lxc_id=105` | `200`, `pct stop`+`destroy` ran | `400`, nothing ran |
| legitimate `POST` with JSON body | `200` | `200` |
| `GET /resource/lxc/config?lxc_id=104` (#14) | `200` | `200` |

The query string is now read only for GET and HEAD — all issue #14 ever needed.

## Authentication could not be turned on

Neither model client sent a key, and `require_api_key` has no localhost
exemption. So `authentication.enabled: true` — which three documentation pages
instruct the operator to set — 401'd every config fetch and every scaling call.
The failures were logged as a generic "client error", so the symptom was
"autoscaling stopped for no reason" and the natural response was to turn it back
off, leaving a root-equivalent API open on every interface.

Both clients now send `X-API-Key` from `api.api_key`, and a 401/403 is logged as
a configuration error naming the setting.

## The one secret was world-readable and written to a log

- configs installed **0600** in a **0750** directory (they were 0644 in 0755)
- `?api_key=` no longer accepted — gunicorn's default access log writes the full
  request line, so the key landed in `/var/log/lxc_autoscale_api_access.log`
- the access log format now omits the query string

## The rate limiter defeated itself

`max_requests: 500` recycled the single worker, and gthread counts a request
*before* the app sees it — so an attacker's own 429s drove the recycle that
cleared their window.

Turning that off required fixing eviction first: the window was pruned only for
the IP currently being served, so disabling recycling alone would have converted
a throttle bug into unbounded attacker-keyed memory growth. **The audit's
verifiers disagreed on this one across three dimensions and one recommended
exactly that harmful fix**; the eviction lands first here.

## Smaller

- documented `X-RateLimit-*` headers were unreachable on success — the views
  return Flask's `(body, status)` tuple, which has no `.headers`
- `/health/check` forked a root `pct list` per anonymous request; now cached and
  throttled
- `/routes` had no limiter, and it is the route the docs tell you to `curl -I`
- a non-ASCII configured key made **every** request 500 via `compare_digest`
- a snapshot name could start with `-` and be read by `pct` as an option
- the `method` metric label was attacker-controlled on unmatched routes, which
  never reach the per-view limiter

## Tests assert properties, not implementations

`tests/test_security.py` adds a route→protection table checked **behaviourally**
(an introspective version was written first and discarded — `@wraps` hides the
decorator names, and what matters is whether a caller is actually rejected).

Stripping `@require_api_key` from `/clone/delete` — a mutation the previous
suite survived — now fails.

291 tests on Python 3.11, 3.12, 3.13. `ruff` and `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
