### PR TITLE
fix(install): a fresh install could never start the model service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,12 +8,16 @@ set -euo pipefail
 LOGFILE="lxc_autoscale_ml_installer.log"
 
 # Define text styles and emojis
-BOLD=$(tput bold)
-RESET=$(tput sgr0)
-GREEN=$(tput setaf 2)
-RED=$(tput setaf 1)
-YELLOW=$(tput setaf 3)
-BLUE=$(tput setaf 4)
+# Guarded: under `set -euo pipefail`, an unset or dumb TERM made tput fail and
+# aborted the whole script at line 11 -- which is exactly the documented
+# `curl | bash` case from cron or Ansible.
+if [[ -t 1 ]] && command -v tput >/dev/null 2>&1 && tput setaf 1 >/dev/null 2>&1; then
+    BOLD=$(tput bold); RESET=$(tput sgr0)
+    GREEN=$(tput setaf 2); RED=$(tput setaf 1)
+    YELLOW=$(tput setaf 3); BLUE=$(tput setaf 4)
+else
+    BOLD=""; RESET=""; GREEN=""; RED=""; YELLOW=""; BLUE=""
+fi
 CHECKMARK="\xE2\x9C\x85"
 CROSSMARK="\xE2\x9D\x8C"
 WARNING="\xE2\x9A\xA0"
@@ -60,10 +64,17 @@ check_software() {
         log "INFO" "Python3 is installed." "$CHECKMARK"
     fi
 
-    REQUIRED_SYSTEM_PACKAGES=("git" "gunicorn" "python3-flask" "python3-requests" "python3-sklearn" "python3-pandas" "python3-numpy" "python3-aiofiles" "python3-psutil" "python3-yaml")
+    # Every third-party module imported at the top level of a deployed file must
+    # appear here. tests/test_install_contract.py enforces that: python3-aiohttp
+    # was missing since the async client was introduced, so the model service
+    # could not start on ANY fresh install -- it logged an ERROR, the installer
+    # printed "Installation process complete!" and exited 0.
+    REQUIRED_SYSTEM_PACKAGES=("git" "gunicorn" "python3-flask" "python3-requests" "python3-sklearn" "python3-pandas" "python3-numpy" "python3-aiohttp" "python3-aiofiles" "python3-psutil" "python3-yaml" "python3-prometheus-client")
 
     for package in "${REQUIRED_SYSTEM_PACKAGES[@]}"; do
-        if dpkg -l | grep -qw "$package"; then
+        # dpkg -l | grep -qw matched the version and description columns, and
+        # matched removed-but-not-purged (rc) records as installed.
+        if [[ "$(dpkg-query -W -f='${db:Status-Status}' "$package" 2>/dev/null)" == "installed" ]]; then
             log "INFO" "System package $package is already installed." "$CHECKMARK"
         else
             log "INFO" "Installing system package: $package..." "$INFO"
@@ -108,7 +119,9 @@ install_lxc_autoscale_ml() {
     log "INFO" "Installing LXC AutoScale ML..." "$INFO"
 
     # Disable and stop services if running
-    systemctl disable lxc_autoscale_ml.service lxc_autoscale_api.service lxc_monitor.service 2>/dev/null || true
+    # Stop only. Disabling here meant a later failure -- a failed git clone,
+    # say -- left a previously working install disabled, so it did not come
+    # back after a reboot either. setup_service re-enables at the end.
     systemctl stop lxc_autoscale_ml.service lxc_autoscale_api.service lxc_monitor.service 2>/dev/null || true
 
     # Reload systemd
@@ -122,9 +135,12 @@ install_lxc_autoscale_ml() {
     # Clone the repository
     REPO_URL="https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml.git"
     TEMP_DIR=$(mktemp -d)
+    # Override to install a tag rather than the default branch:
+    #   LXC_AUTOSCALE_REF=v1.4.0 ./install.sh
+    REF="${LXC_AUTOSCALE_REF:-}"
 
-    log "INFO" "Cloning the repository from $REPO_URL..." "$INFO"
-    if git clone "$REPO_URL" "$TEMP_DIR"; then
+    log "INFO" "Cloning the repository from $REPO_URL${REF:+ at $REF}..." "$INFO"
+    if git clone ${REF:+--branch "$REF"} --depth 1 "$REPO_URL" "$TEMP_DIR"; then
         log "INFO" "Successfully cloned the repository." "$CHECKMARK"
     else
         log "ERROR" "Failed to clone the repository." "$CROSSMARK"
@@ -195,14 +211,25 @@ move_files() {
 setup_service() {
     local service_name="$1"
     if systemctl enable "$service_name" && systemctl start "$service_name"; then
-        log "INFO" "${CHECKMARK} Service $service_name started successfully!" "$CHECKMARK"
+        log "SUCCESS" "Service $service_name started successfully!" "$CHECKMARK"
     else
-        log "ERROR" "${CROSSMARK} Failed to start service $service_name." "$CROSSMARK"
+        # Previously this logged an error and the installer still printed
+        # "Installation process complete!" and exited 0, so a missing
+        # dependency looked like a successful install.
+        log "ERROR" "Failed to start service $service_name." "$CROSSMARK"
         systemctl status "$service_name" --no-pager || true
+        journalctl -u "$service_name" -n 30 --no-pager || true
+        return 1
     fi
 }
 
 # Main script execution
+if [[ ${EUID} -ne 0 ]]; then
+    echo "This installer writes to /etc, /usr/local/bin and /etc/systemd/system." >&2
+    echo "Re-run it as root." >&2
+    exit 1
+fi
+
 header
 check_software
 backup_files

--- a/lxc_autoscale_ml/api/lxc_autoscale_api.service
+++ b/lxc_autoscale_ml/api/lxc_autoscale_api.service
@@ -1,20 +1,37 @@
 [Unit]
 Description=LXC AutoScale API
 Documentation=https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=root
 Group=root
 Environment="PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin"
+Environment="PYTHONUNBUFFERED=1"
 WorkingDirectory=/usr/local/bin/lxc_autoscale_api/
 ExecStart=/usr/bin/gunicorn --config /usr/local/bin/lxc_autoscale_api/gunicorn_config.py
 ExecReload=/bin/kill -s HUP $MAINPID
 KillMode=mixed
 
-# Restart on failure
+# The configuration holds authentication.api_keys.
+UMask=0077
+
+# A failed start must back off. With the default RestartSec (100ms) and
+# StartLimitBurst, a persistent failure -- a missing dependency, say -- burned
+# through the burst in under a second and latched the unit `failed` rather than
+# retrying, which is how a broken install looked like a dead service with no
+# restart attempts in the journal.
 Restart=on-failure
-RestartSec=5
+RestartSec=15
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+# No filesystem or privilege hardening here, deliberately. These services exist
+# to run `pct`, which manipulates container mounts, cgroups and namespaces;
+# ProtectSystem, PrivateMounts, NoNewPrivileges and friends break it. The
+# mitigation that does apply is not running the API on a public interface --
+# see server.host in lxc_autoscale_api.yaml.
 
 [Install]
 WantedBy=multi-user.target

--- a/lxc_autoscale_ml/model/lxc_autoscale_ml.service
+++ b/lxc_autoscale_ml/model/lxc_autoscale_ml.service
@@ -1,19 +1,41 @@
 [Unit]
 Description=LXC AutoScale ML Service
 Documentation=https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml
-After=network.target
+After=network-online.target lxc_monitor.service lxc_autoscale_api.service
+Wants=network-online.target
+
+# The model reads the file the monitor writes and calls the API to act. It
+# tolerates both being absent -- it skips the cycle -- but starting after them
+# avoids a first cycle that can only fail.
+Wants=lxc_monitor.service lxc_autoscale_api.service
 
 [Service]
+User=root
 ExecStart=/usr/bin/python3 /usr/local/bin/lxc_autoscale_ml/lxc_autoscale_ml.py
 WorkingDirectory=/usr/local/bin/lxc_autoscale_ml
 StandardOutput=inherit
 StandardError=inherit
-Restart=on-failure
-User=root
-
-# Logging configuration
 Environment="PYTHONUNBUFFERED=1"
-EnvironmentFile=/etc/lxc_autoscale_ml/lxc_autoscale_ml.yaml
+
+# No EnvironmentFile. It used to point at lxc_autoscale_ml.yaml, but systemd
+# expects KEY=value lines and that file is YAML; the configuration is read by
+# the Python process itself.
+
+# A failed start must back off. With the default RestartSec (100ms) and
+# StartLimitBurst, a persistent failure -- a missing dependency, say -- burned
+# through the burst in under a second and latched the unit `failed` rather than
+# retrying, which is how a broken install looked like a dead service with no
+# restart attempts in the journal.
+Restart=on-failure
+RestartSec=15
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+# No filesystem or privilege hardening here, deliberately. These services exist
+# to run `pct`, which manipulates container mounts, cgroups and namespaces;
+# ProtectSystem, PrivateMounts, NoNewPrivileges and friends break it. The
+# mitigation that does apply is not running the API on a public interface --
+# see server.host in lxc_autoscale_api.yaml.
 
 [Install]
 WantedBy=multi-user.target

--- a/lxc_autoscale_ml/monitor/lxc_monitor.service
+++ b/lxc_autoscale_ml/monitor/lxc_monitor.service
@@ -1,19 +1,32 @@
 [Unit]
 Description=LXC Monitor Service
 Documentation=https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
+User=root
 ExecStart=/usr/bin/python3 /usr/local/bin/lxc_monitor.py
 WorkingDirectory=/usr/local/bin/
 StandardOutput=inherit
 StandardError=inherit
-Restart=on-failure
-User=root
-
-# Logging configuration
 Environment="PYTHONUNBUFFERED=1"
-EnvironmentFile=-/etc/lxc_autoscale_ml/lxc_monitor.yaml
+
+# A failed start must back off. With the default RestartSec (100ms) and
+# StartLimitBurst, a persistent failure -- a missing dependency, say -- burned
+# through the burst in under a second and latched the unit `failed` rather than
+# retrying, which is how a broken install looked like a dead service with no
+# restart attempts in the journal.
+Restart=on-failure
+RestartSec=15
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+# No filesystem or privilege hardening here, deliberately. These services exist
+# to run `pct`, which manipulates container mounts, cgroups and namespaces;
+# ProtectSystem, PrivateMounts, NoNewPrivileges and friends break it. The
+# mitigation that does apply is not running the API on a public interface --
+# see server.host in lxc_autoscale_api.yaml.
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/test_install_contract.py
+++ b/tests/test_install_contract.py
@@ -1,0 +1,199 @@
+"""The installer must install what the deployed code imports.
+
+`python3-aiohttp` was missing from install.sh since the async client was
+introduced, so the model service could not start on *any* fresh install -- and
+the installer still exited 0 reporting success. `tests/test_config_contract.py`
+checks only the ExecStart binaries, so it structurally could not catch this.
+"""
+import ast
+import pathlib
+import re
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+INSTALL_SH = ROOT / "install.sh"
+
+# Deployed trees, and where install.sh puts them.
+DEPLOYED = [
+    ROOT / "lxc_autoscale_ml/api",
+    ROOT / "lxc_autoscale_ml/model",
+    ROOT / "lxc_autoscale_ml/monitor",
+]
+
+# Third-party distribution -> Debian package installed by install.sh.
+DEBIAN_PACKAGE = {
+    "flask": "python3-flask",
+    "requests": "python3-requests",
+    "sklearn": "python3-sklearn",
+    "pandas": "python3-pandas",
+    "numpy": "python3-numpy",
+    "aiohttp": "python3-aiohttp",
+    "aiofiles": "python3-aiofiles",
+    "psutil": "python3-psutil",
+    "yaml": "python3-yaml",
+    "prometheus_client": "python3-prometheus-client",
+    "gunicorn": "gunicorn",
+}
+
+
+def required_packages():
+    match = re.search(r"REQUIRED_SYSTEM_PACKAGES=\(([^)]*)\)", INSTALL_SH.read_text(), re.S)
+    assert match, "could not find REQUIRED_SYSTEM_PACKAGES in install.sh"
+    return {p.strip('"') for p in match.group(1).split() if p.strip('"')}
+
+
+def top_level_imports(path):
+    """Modules imported unconditionally at module scope.
+
+    Imports inside a try/except ImportError are optional by construction --
+    metrics.py guards prometheus_client that way -- so they are excluded.
+    """
+    tree = ast.parse(path.read_text())
+    names = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            names.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module.split(".")[0])
+    return names
+
+
+def local_module_names():
+    names = set()
+    for directory in DEPLOYED:
+        names.update(p.stem for p in directory.glob("*.py"))
+    return names
+
+
+ALL_MODULES = sorted(p for d in DEPLOYED for p in d.glob("*.py"))
+
+
+@pytest.mark.parametrize("module", ALL_MODULES, ids=lambda p: p.name)
+def test_every_unconditional_import_is_installed(module):
+    packages = required_packages()
+    local = local_module_names()
+    stdlib = set(getattr(sys, "stdlib_module_names", ()))
+
+    missing = []
+    for name in sorted(top_level_imports(module)):
+        if name in local or name in stdlib or name.startswith("_"):
+            continue
+        package = DEBIAN_PACKAGE.get(name)
+        assert package, (
+            f"{module.name} imports {name!r}, which this test does not know how "
+            f"to map to a Debian package. Add it to DEBIAN_PACKAGE."
+        )
+        if package not in packages:
+            missing.append(f"{name} (needs {package})")
+
+    assert not missing, (
+        f"{module.name} imports {missing} but install.sh does not install "
+        f"{'them' if len(missing) > 1 else 'it'}. A fresh install cannot run this file."
+    )
+
+
+def test_the_installer_covers_the_runtime_requirements():
+    """requirements.txt and install.sh are two different dependency lists and
+    only one of them is deployed. They must not disagree about what is needed.
+    """
+    packages = required_packages()
+    declared = []
+    for line in (ROOT / "requirements.txt").read_text().splitlines():
+        line = line.split("#")[0].strip()
+        if not line:
+            continue
+        declared.append(re.split(r"[=<>!]", line)[0].strip())
+
+    pypi_to_import = {
+        "Flask": "flask", "scikit-learn": "sklearn", "PyYAML": "yaml",
+        "prometheus-client": "prometheus_client",
+    }
+    missing = []
+    for dist in declared:
+        module = pypi_to_import.get(dist, dist.lower().replace("-", "_"))
+        package = DEBIAN_PACKAGE.get(module)
+        if package and package not in packages:
+            missing.append(f"{dist} -> {package}")
+    assert not missing, (
+        f"requirements.txt declares {missing}, which install.sh never installs"
+    )
+
+
+def test_a_failed_service_start_is_fatal():
+    """The installer used to log the error and still print
+    "Installation process complete!" and exit 0."""
+    text = INSTALL_SH.read_text()
+    setup = text[text.index("setup_service()"):]
+    setup = setup[:setup.index("\n}")]
+    assert "return 1" in setup, "setup_service does not propagate a failure"
+
+
+def test_the_installer_requires_root():
+    assert "EUID" in INSTALL_SH.read_text()
+
+
+class TestServiceUnitContract:
+    UNITS = sorted((ROOT / "lxc_autoscale_ml").rglob("*.service"))
+
+    def _directives(self, unit):
+        out = {}
+        for line in unit.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith(("#", "[")):
+                continue
+            key, sep, value = line.partition("=")
+            if sep:
+                out.setdefault(key.strip(), []).append(value.strip())
+        return out
+
+    @pytest.mark.parametrize("unit", UNITS, ids=lambda p: p.name)
+    def test_no_yaml_is_fed_to_systemd_as_an_environment_file(self, unit):
+        """The model unit pointed EnvironmentFile at a YAML file. systemd
+        expects KEY=value; the configuration is read by Python."""
+        for value in self._directives(unit).get("EnvironmentFile", []):
+            assert not value.lstrip("-").endswith((".yaml", ".yml")), (
+                f"{unit.name} feeds a YAML file to systemd as an EnvironmentFile"
+            )
+
+    @pytest.mark.parametrize("unit", UNITS, ids=lambda p: p.name)
+    def test_restart_backs_off(self, unit):
+        """With the default RestartSec a persistent failure burned the start
+        limit in under a second and latched the unit `failed`, with no restart
+        attempts visible in the journal."""
+        directives = self._directives(unit)
+        assert directives.get("Restart") == ["on-failure"]
+        assert int(directives["RestartSec"][0]) >= 5, f"{unit.name} restarts too eagerly"
+
+    @pytest.mark.parametrize("unit", UNITS, ids=lambda p: p.name)
+    def test_exec_start_paths_match_the_installer(self, unit):
+        install = INSTALL_SH.read_text()
+        exec_start = self._directives(unit)["ExecStart"][0]
+        for token in exec_start.split():
+            if not token.startswith("/"):
+                continue
+            name = pathlib.Path(token).name
+            if name in ("python3", "gunicorn"):
+                assert name in install
+                continue
+            sources = list((ROOT / "lxc_autoscale_ml").rglob(name))
+            assert sources, f"{unit.name} runs {token}, absent from this repository"
+            directory = sources[0].parent.name
+            assert name in install or f'/{directory}/"*.py' in install, (
+                f"{unit.name} runs {token}, which install.sh never places there"
+            )
+
+    def test_the_model_starts_after_what_it_depends_on(self):
+        """It reads the monitor's file and calls the API."""
+        after = " ".join(self._directives(
+            ROOT / "lxc_autoscale_ml/model/lxc_autoscale_ml.service")["After"])
+        assert "lxc_monitor.service" in after
+        assert "lxc_autoscale_api.service" in after
+
+    def test_the_api_unit_masks_its_secrets(self):
+        directives = self._directives(
+            ROOT / "lxc_autoscale_ml/api/lxc_autoscale_api.service")
+        assert directives.get("UMask") == ["0077"], (
+            "the API writes an access log; without a UMask it is world-readable"
+        )


### PR DESCRIPTION
Stacked on #43 (monitor). **Safe to merge only now** — see below.

## A fresh install could never start the model service

`install.sh` has **never** contained `python3-aiohttp`, since the very commit
that introduced `async_api_client.py` and the top-level import of it:

```
$ git log --oneline -S"aiohttp" -- install.sh
(empty)
$ git log --oneline --diff-filter=A -- lxc_autoscale_ml/model/async_api_client.py
122037c Fix rate limiting issues, ... and implement async batch API fetching
```

So on every `curl … | bash` install the model died on import, the installer
logged an ERROR, then printed **"Installation process complete!"** and exited 0.
`docs/guide/installation.md` lists the package for the manual path — so the
manual path worked and the advertised one did not.

### Why this could not be fixed earlier

That broken installer was the only thing preventing the scaling inversion in
#41 from shrinking every container on the node to its floor. Fixing it before
#41 landed would have converted a dead service into an actively destructive one.
#41 is on `main`, so it is safe now.

### The guard

`tests/test_install_contract.py` AST-walks every deployed module for
unconditional top-level third-party imports and asserts each maps to a package
the installer requests. Imports guarded by `try/except ImportError` are excluded
by construction — which is the right answer for `prometheus_client`: `metrics.py`
guards it and the docs list it as optional, so its absence disables `/metrics`
rather than breaking anything. (An auditor filed it as equally critical; the
verifier correctly called it a red herring.)

Removing `python3-aiohttp` again fails two tests.

## Other installer defects

- **A failed service start was not fatal** — combined with the above, a missing
  dependency looked like a successful install. Now returns non-zero and dumps
  the last 30 journal lines.
- **Six unguarded `tput` calls** aborted the script at line 11 under
  `set -euo pipefail` when `TERM` is unset or dumb — exactly the documented
  `curl | bash` from cron or Ansible.
- **Units were disabled before any fallible work**, so a failed `git clone` left
  a previously working install *disabled*, and it did not come back after a
  reboot either.
- **`dpkg -l | grep -qw`** matched the version and description columns and
  counted removed-but-not-purged (`rc`) packages as installed.
- **`git clone` pinned no ref**, so `git clone -b v1.3.0 && ./install.sh`
  silently installed default-branch HEAD. `LXC_AUTOSCALE_REF` now selects a tag.
- **No root check.**

## systemd units

- **The model unit fed a YAML file to systemd as an `EnvironmentFile`**, without
  even the `-` tolerance prefix. systemd expects `KEY=value` lines; the config
  is read by the Python process. Removed.
- **`Restart=on-failure` with no `RestartSec`**: the default 100ms retry burned
  `StartLimitBurst` in under a second and latched the unit `failed`, so a broken
  install presented as a dead service with *no restart attempts in the journal*.
  Now 15s with an explicit start limit.
- **No ordering between the three units.** The model reads the monitor's file
  and calls the API; it now starts after both.
- `UMask=0077` on the API unit, which writes an access log.

**No filesystem or privilege hardening was added, deliberately.** These services
exist to run `pct`, which manipulates container mounts, cgroups and namespaces;
`ProtectSystem`, `NoNewPrivileges` and friends break it. That is now stated in
the units rather than left looking like an oversight.

341 tests. `ruff` and `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
