### PR TITLE
fix(model): make the tuning knobs mean what they say

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -41,8 +41,10 @@ server:
   port: 5000
 
 lxc:
-  # Name or IP address of the Proxmox node where LXC containers are managed.
-  node: "proxmox"  # Replace with your Proxmox node name or IP. Note: if node name or hostname won't work use IP address instead, should work as expected.
+  # Name of the Proxmox node this API manages. Informational only: every pct
+  # call is local, so this cannot point the API at a different node. Running it
+  # against another host would need pvesh, which this project does not use.
+  node: "proxmox"
   
   # Default storage location for LXC containers.
   default_storage: "local-lvm"  # Default storage location
@@ -248,7 +250,12 @@ interval_seconds: 600  # Time interval between consecutive script runs in second
 circuit_breaker:
   enabled: true  # Stop calling the API for a container after repeated failures
   failure_threshold: 3  # Consecutive failures before the circuit opens
-  timeout_seconds: 300  # How long the circuit stays open before retrying
+  # How long the circuit stays open before retrying. This MUST be longer than
+  # interval_seconds: the breaker is consulted once per container per cycle, so
+  # a window shorter than the interval has always expired by the time it is
+  # asked and blocks nothing. At the shipped 600s interval, 300s blocked zero
+  # calls in ten consecutive failing cycles.
+  timeout_seconds: 1800
 
 # Ignored Containers
 # Container IDs to exclude from autoscaling. An empty list scales everything.
@@ -408,7 +415,7 @@ state. Gunicorn logs a warning at startup if `workers` is above 1.
 | `scaling.dry_run` | boolean | `false` | Log decisions without calling the API |
 | `circuit_breaker.enabled` | boolean | `true` | Stop calling the API for a container after repeated failures |
 | `circuit_breaker.failure_threshold` | integer | `3` | Consecutive failures before the circuit opens |
-| `circuit_breaker.timeout_seconds` | integer | `300` | How long it stays open |
+| `circuit_breaker.timeout_seconds` | integer | `1800` | How long it stays open. Must exceed `interval_seconds`: the breaker is consulted once per container per cycle, so a shorter window has always expired by then and blocks nothing. The model warns at startup if it does not. |
 | `ignore_lxc` | list | `[]` | Container IDs to skip. Matched as strings, so `[101]` and `["101"]` both work. |
 
 On confidence: it is the distance of the prediction from the model's decision

--- a/lxc_autoscale_ml/api/health_check.py
+++ b/lxc_autoscale_ml/api/health_check.py
@@ -11,7 +11,7 @@ import subprocess
 import threading
 import time
 
-from flask import current_app, jsonify
+from flask import jsonify
 
 # The health check must answer quickly even when the node is struggling.
 PROBE_TIMEOUT_SECONDS = 5
@@ -69,15 +69,12 @@ def health_check():
     checks["lxc_commands"] = {"ok": pct_ok, "detail": pct_detail}
     healthy = healthy and pct_ok
 
-    # Configuration is loaded once at startup; report whether the node the API
-    # is supposed to manage was actually configured.
-    node = current_app.config.get("LXC_NODE")
-    node_ok = bool(node)
-    checks["configuration"] = {
-        "ok": node_ok,
-        "detail": f"node={node}" if node_ok else "lxc.node is not configured",
-    }
-    healthy = healthy and node_ok
+    # There used to be a "configuration" check here asserting that `lxc.node`
+    # was set. It is stored by create_app and read by nothing -- every `pct`
+    # call is local -- so it was a truthiness test on an unused value, always
+    # true with the shipped config. Half of a health check written under the
+    # banner "a health check that cannot fail is worse than none" could not
+    # fail. Removed rather than left as decoration.
 
     if not healthy:
         failing = [name for name, check in checks.items() if not check["ok"]]

--- a/lxc_autoscale_ml/api/lxc_autoscale_api.yaml
+++ b/lxc_autoscale_ml/api/lxc_autoscale_api.yaml
@@ -10,8 +10,10 @@ server:
   port: 5000
 
 lxc:
-  # Name or IP address of the Proxmox node where LXC containers are managed.
-  node: "proxmox"  # Replace with your Proxmox node name or IP. Note: if node name or hostname won't work use IP address instead, should work as expected.
+  # Name of the Proxmox node this API manages. Informational only: every pct
+  # call is local, so this cannot point the API at a different node. Running it
+  # against another host would need pvesh, which this project does not use.
+  node: "proxmox"
   
   # Default storage location for LXC containers.
   default_storage: "local-lvm"  # Default storage location

--- a/lxc_autoscale_ml/model/config_manager.py
+++ b/lxc_autoscale_ml/model/config_manager.py
@@ -34,7 +34,11 @@ def load_config(config_path, default_config=None):
         config = {**default_config, **config}
         logging.debug("Configuration merged with default values.")
 
-    required_keys = ['log_file', 'interval_seconds', 'api']
+    # `scaling` was absent from this list while evaluate_container and
+    # determine_scaling_action both index config["scaling"] directly, so a
+    # config that passed validation raised KeyError for every container, every
+    # cycle -- logged as a traceback forever while the unit reported healthy.
+    required_keys = ['log_file', 'interval_seconds', 'api', 'scaling']
     for key in required_keys:
         if key not in config:
             logging.error(f"Missing required configuration key: {key}")
@@ -62,7 +66,7 @@ def validate_scaling_config(config):
         ConfigError: If configuration is invalid
     """
     if 'scaling' not in config:
-        return  # Scaling config is optional
+        raise ConfigError("Missing required configuration section: scaling")
 
     scaling = config['scaling']
 
@@ -100,5 +104,26 @@ def validate_scaling_config(config):
 
     if scaling.get('ram_scale_step_mb', 1) <= 0:
         raise ConfigError("ram_scale_step_mb must be positive")
+
+    min_confidence = scaling.get('min_confidence', 0)
+    if not isinstance(min_confidence, (int, float)) or not (0 <= min_confidence <= 100):
+        raise ConfigError(
+            f"min_confidence must be a number between 0 and 100, got {min_confidence!r}")
+
+    # M1: the breaker is consulted once per container per cycle. If its window
+    # closes before the next cycle begins it has always expired by the time it
+    # is asked, so it blocks nothing -- with the shipped 300s window and 600s
+    # interval it blocked zero calls in ten consecutive failing cycles.
+    interval = config.get('interval_seconds', 60)
+    breaker = config.get('circuit_breaker') or {}
+    if breaker.get('enabled', True):
+        timeout = breaker.get('timeout_seconds', 300)
+        if timeout <= interval:
+            logging.warning(
+                f"circuit_breaker.timeout_seconds ({timeout}s) is not longer than "
+                f"interval_seconds ({interval}s). The breaker is consulted once per "
+                f"container per cycle, so its window will always have expired by then "
+                f"and it will never block a call. Set it above the interval."
+            )
 
     logging.info("Scaling configuration validated successfully")

--- a/lxc_autoscale_ml/model/lxc_autoscale_ml.yaml
+++ b/lxc_autoscale_ml/model/lxc_autoscale_ml.yaml
@@ -83,7 +83,12 @@ interval_seconds: 600  # Time interval between consecutive script runs in second
 circuit_breaker:
   enabled: true  # Stop calling the API for a container after repeated failures
   failure_threshold: 3  # Consecutive failures before the circuit opens
-  timeout_seconds: 300  # How long the circuit stays open before retrying
+  # How long the circuit stays open before retrying. This MUST be longer than
+  # interval_seconds: the breaker is consulted once per container per cycle, so
+  # a window shorter than the interval has always expired by the time it is
+  # asked and blocks nothing. At the shipped 600s interval, 300s blocked zero
+  # calls in ten consecutive failing cycles.
+  timeout_seconds: 1800
 
 # Ignored Containers
 # Container IDs to exclude from autoscaling. An empty list scales everything.

--- a/lxc_autoscale_ml/model/model.py
+++ b/lxc_autoscale_ml/model/model.py
@@ -24,6 +24,9 @@ def train_anomaly_models(df, config):
             ('IsolationForest', model)
         ])
         pipeline.fit(X_train)
+        # Keep the training-score distribution on the pipeline: score_to_confidence
+        # expresses a sample's distance from the boundary as a percentile of it.
+        pipeline.training_abs_scores_ = np.abs(pipeline.decision_function(X_train))
         logging.info("IsolationForest model training completed.")
         return pipeline, features_to_use  # Return both the model and the feature set used
     except Exception as e:
@@ -31,25 +34,31 @@ def train_anomaly_models(df, config):
         return None, None
 
 
-# IsolationForest.decision_function returns a signed distance from the decision
-# boundary, positive for inliers and negative for outliers, in practice within
-# roughly +/-0.5. Anything at or beyond this distance counts as full confidence.
-DECISION_SCORE_SCALE = 0.5
-
-
-def score_to_confidence(anomaly_score):
+def score_to_confidence(anomaly_score, training_scores=None):
     """
     Map an IsolationForest decision score onto a 0-100 confidence.
 
-    Confidence means "how far this sample is from the decision boundary", so 0
-    is a borderline call and 100 is unambiguous, in either direction.
+    Confidence is the percentile of this sample's distance from the decision
+    boundary among the distances seen during training: 90 means "further from
+    the boundary than 90% of the history this model was fitted on".
 
-    The previous formula was `(1 - score) * 100`, which produced roughly
-    50-150% -- never below 50 and not bounded by 100 -- so it could not be
-    compared against a percentage threshold the way the documentation claimed.
+    Two earlier definitions were wrong in opposite directions. `(1 - score) *
+    100` produced roughly 50-150%, so it was never below 50 and not bounded by
+    100. Dividing by a hard-coded 0.5 assumed a spread about four times the
+    real one -- measured `|decision_function|` tops out near 0.14 -- so
+    confidence never exceeded about 27%, and any `min_confidence` above that
+    silently disabled all scaling. The documented "cautious" preset used 80.
+
+    Deriving the scale from the model's own training scores removes the
+    invented constant: the full 0-100 range is reachable by construction, and
+    a threshold means the same thing whatever the data looks like.
     """
-    confidence = abs(float(anomaly_score)) / DECISION_SCORE_SCALE * 100.0
-    return max(0.0, min(100.0, confidence))
+    score = abs(float(anomaly_score))
+    if training_scores is None or len(training_scores) == 0:
+        # No reference distribution: report nothing rather than a number that
+        # cannot be compared against a threshold.
+        return 0.0
+    return float((np.asarray(training_scores) <= score).mean() * 100.0)
 
 
 def predict_anomalies(model, latest_metrics, features_to_use, config):
@@ -62,7 +71,8 @@ def predict_anomalies(model, latest_metrics, features_to_use, config):
         anomaly_score = model.decision_function(latest_metrics_df)
         # Convert anomaly_score to a scalar if it's an array
         anomaly_score = anomaly_score.item() if isinstance(anomaly_score, np.ndarray) else anomaly_score
-        confidence = score_to_confidence(anomaly_score)
+        confidence = score_to_confidence(
+            anomaly_score, getattr(model, "training_abs_scores_", None))
         logging.debug(f"Anomaly score: {anomaly_score}, Confidence: {confidence:.2f}%")
         prediction = model.predict(latest_metrics_df)
         prediction = prediction.item() if isinstance(prediction, np.ndarray) else prediction

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -244,14 +244,16 @@ class TestOperationalEndpoints:
         assert payload["status"] == "unhealthy"
         assert payload["checks"]["lxc_commands"]["detail"] == "pct not found in PATH"
 
-    def test_health_check_flags_an_unconfigured_node(self, app, client, monkeypatch):
+    def test_health_check_has_no_check_that_cannot_fail(self, client, monkeypatch):
+        """It used to assert `lxc.node` was set -- a value create_app stores and
+        nothing reads, always true with the shipped config. Half of a health
+        check written under "a health check that cannot fail is worse than
+        none" could not fail."""
         import health_check
 
         monkeypatch.setattr(health_check, "_check_pct", lambda: (True, "ok"))
-        monkeypatch.setitem(app.config, "LXC_NODE", None)
-        response = client.get("/health/check")
-        assert response.status_code == 503
-        assert response.get_json()["checks"]["configuration"]["ok"] is False
+        checks = client.get("/health/check").get_json()["checks"]
+        assert set(checks) == {"lxc_commands"}
 
     def test_metrics_endpoint_is_registered(self, client):
         response = client.get("/metrics")

--- a/tests/test_model_pipeline.py
+++ b/tests/test_model_pipeline.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 from data_manager import load_data, preprocess_data
-from model import DECISION_SCORE_SCALE, predict_anomalies, score_to_confidence, train_anomaly_models
+from model import predict_anomalies, score_to_confidence, train_anomaly_models
 
 
 BASE_CONFIG = {
@@ -136,24 +136,59 @@ class TestPreprocessing:
 
 
 class TestConfidence:
+    """Confidence is the percentile of a sample's distance from the decision
+    boundary among the distances seen during training.
+
+    Two earlier definitions were wrong in opposite directions: `(1 - score)*100`
+    produced 50-150%, and dividing by a hard-coded 0.5 assumed a spread about
+    four times the real one, capping confidence near 27% -- so any
+    `min_confidence` above that silently disabled all scaling, and the
+    documented "cautious" preset used 80.
+    """
+
+    TRAINING = np.linspace(0.0, 0.14, 100)
+
     def test_is_bounded_to_a_percentage(self):
-        """The old formula was (1 - score) * 100: roughly 50-150%, so it could
-        never be compared against a percentage threshold."""
         for score in [-10, -0.5, -0.1, 0, 0.1, 0.5, 10]:
-            assert 0.0 <= score_to_confidence(score) <= 100.0
+            assert 0.0 <= score_to_confidence(score, self.TRAINING) <= 100.0
 
-    def test_boundary_scores_are_zero_confidence(self):
-        assert score_to_confidence(0.0) == 0.0
+    def test_the_whole_range_is_reachable(self):
+        """The point of the fix: a threshold of 80 must be attainable."""
+        assert score_to_confidence(self.TRAINING.max(), self.TRAINING) == 100.0
+        assert score_to_confidence(0.0, self.TRAINING) > 0.0
+        high = score_to_confidence(np.percentile(self.TRAINING, 90), self.TRAINING)
+        assert high >= 80.0, "a documented min_confidence of 80 must be reachable"
 
-    def test_confidence_grows_with_distance_from_the_boundary(self):
-        assert score_to_confidence(0.1) < score_to_confidence(0.3) < score_to_confidence(0.5)
+    def test_it_is_a_percentile_of_the_training_distribution(self):
+        median = float(np.median(self.TRAINING))
+        assert score_to_confidence(median, self.TRAINING) == pytest.approx(50.0, abs=2.0)
 
-    def test_is_symmetric_around_the_boundary(self):
-        assert score_to_confidence(-0.2) == score_to_confidence(0.2)
+    def test_it_grows_with_distance_from_the_boundary(self):
+        values = [score_to_confidence(s, self.TRAINING) for s in (0.01, 0.05, 0.12)]
+        assert values == sorted(values)
 
-    def test_saturates_at_the_scale(self):
-        assert score_to_confidence(DECISION_SCORE_SCALE) == 100.0
-        assert score_to_confidence(DECISION_SCORE_SCALE * 5) == 100.0
+    def test_it_is_symmetric_around_the_boundary(self):
+        assert (score_to_confidence(-0.05, self.TRAINING)
+                == score_to_confidence(0.05, self.TRAINING))
+
+    def test_without_a_reference_distribution_it_reports_nothing(self):
+        """Rather than a number that cannot be compared against a threshold."""
+        assert score_to_confidence(0.5, None) == 0.0
+        assert score_to_confidence(0.5, []) == 0.0
+
+    def test_a_trained_model_can_produce_a_high_confidence(self, metrics_file):
+        """End to end, against a real fitted pipeline -- the property the
+        hard-coded scale broke."""
+        df = preprocess_data(load_data(metrics_file(cycles=40)), BASE_CONFIG)
+        model, features = train_anomaly_models(df, BASE_CONFIG)
+        confidences = [
+            predict_anomalies(model, df.iloc[i], features, BASE_CONFIG)[1]
+            for i in range(len(df))
+        ]
+        assert max(confidences) >= 90.0, (
+            f"the model cannot express confidence above {max(confidences):.0f}%, "
+            f"so any min_confidence above that disables scaling entirely"
+        )
 
 
 class TestTrainAndPredict:


### PR DESCRIPTION
Three settings the documentation offers were unreachable, inert, or validated
where nothing reads them. Each would have shipped in a release titled
"autoscaling actually works".

## `min_confidence` above ~27 disabled all scaling

`score_to_confidence` divided by a hard-coded `DECISION_SCORE_SCALE = 0.5` —
roughly **four times** the real spread. Measured `|decision_function|` tops out
near 0.14, so confidence never exceeded about 27%.

`docs/reference/configuration.md` ships a **"cautious scaling"** preset with
`min_confidence: 80`. Copying it would have silently stopped the autoscaler, in
the name of caution, with no error anywhere.

That constant was mine, replacing an earlier formula wrong in the other
direction (`(1 - score) * 100`, giving 50–150%). **Guessing a second constant
was the mistake.** Confidence is now the percentile of a sample's distance from
the decision boundary among the distances the model saw during training, taken
from the fitted pipeline itself. The full 0–100 range is reachable by
construction, and a threshold means the same thing whatever the data looks like.

Measured against a real fitted model:

```
confidence: min=1.2%  median=51.2%  max=100.0%
samples above min_confidence=80: 17/80
```

## The circuit breaker could not fire

It is consulted once per container per cycle, so a window shorter than the
interval has always expired by the time it is asked. With the shipped
`timeout_seconds: 300` against `interval_seconds: 600`, it blocked **zero calls
in ten consecutive failing cycles** — pure logging.

Default raised to 1800s, and the model now warns at startup when the
relationship is wrong rather than leaving it silent.

## A config without `scaling` passed validation, then failed forever

`validate_scaling_config` returned early when the section was absent, while
`evaluate_container` and `determine_scaling_action` both index it directly. The
result was a `KeyError` for every container, every cycle, caught by the
per-container handler and logged as a traceback indefinitely — while the unit
reported healthy. Now required, and `min_confidence` is validated as a
percentage.

## Half the health check could not fail

It asserted `lxc.node` was set: a value `create_app` stores and **nothing
reads**, since every `pct` call is local. Always true with the shipped config.

That is in a file whose own docstring says *"a health check that cannot fail is
worse than none"*, so it is removed rather than left as decoration — and the
config comment no longer implies the key can point the API at another node.

501 tests. `ruff` and `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
