### PR TITLE
fix: close the remaining audit items, and document the one that must not be

### DIFF
--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -360,6 +360,20 @@ server {
 }
 ```
 
+::: warning Rate limiting does not work behind this proxy
+The limiter exempts `127.0.0.1`, which is what `proxy_pass` makes every request
+look like. Nothing in the API reads `X-Real-IP` or `X-Forwarded-For`, so with
+nginx in front the per-IP limit is effectively disabled and the "invalid API
+key" warnings all log `127.0.0.1`.
+
+Installing a proxy-header fixer here would be **worse**, not better: with
+`server.host: 0.0.0.0` any client that can reach the port directly could then
+spoof `X-Forwarded-For: 127.0.0.1` and exempt itself. Until the API can be told
+which proxies to trust, rate limit in nginx itself (`limit_req_zone`) and treat
+the API's own limiter as covering only direct callers.
+:::
+
+
 ## Next Steps
 
 - [API Endpoints Reference](/reference/api-endpoints): Complete endpoint documentation

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -111,6 +111,20 @@ server {
 }
 ```
 
+::: warning Rate limiting does not work behind this proxy
+The limiter exempts `127.0.0.1`, which is what `proxy_pass` makes every request
+look like. Nothing in the API reads `X-Real-IP` or `X-Forwarded-For`, so with
+nginx in front the per-IP limit is effectively disabled and the "invalid API
+key" warnings all log `127.0.0.1`.
+
+Installing a proxy-header fixer here would be **worse**, not better: with
+`server.host: 0.0.0.0` any client that can reach the port directly could then
+spoof `X-Forwarded-For: 127.0.0.1` and exempt itself. Until the API can be told
+which proxies to trust, rate limit in nginx itself (`limit_req_zone`) and treat
+the API's own limiter as covering only direct callers.
+:::
+
+
 ## Performance
 
 ### How many containers can it handle?

--- a/lxc_autoscale_ml/api/config.py
+++ b/lxc_autoscale_ml/api/config.py
@@ -7,10 +7,19 @@ from flask import Flask
 
 DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
-def load_config(config_file='/etc/lxc_autoscale_ml/lxc_autoscale_api.yaml'):
+def load_config(config_file=None):
+    """Load the API configuration.
+
+    `or {}` throughout, because a section written but left empty parses to
+    None, and `.get(key, default)` returns that stored None rather than the
+    default -- which surfaced as a raw HTML 500 on every request. The gunicorn
+    config, the monitor and the model config loader all already guarded this;
+    only this file did not.
+    """
+    config_file = config_file or os.environ.get(
+        "LXC_AUTOSCALE_API_CONFIG", "/etc/lxc_autoscale_ml/lxc_autoscale_api.yaml")
     with open(config_file) as file:
-        config = yaml.safe_load(file)
-    return config
+        return yaml.safe_load(file) or {}
 
 def configure_logging(logging_config):
     """
@@ -54,26 +63,26 @@ def create_app(config=None):
     if config is None:
         config = load_config()
 
-    configure_logging(config.get('logging', {}))
+    configure_logging(config.get('logging') or {})
 
-    lxc_config = config.get('lxc', {})
+    lxc_config = (config.get('lxc') or {})
     app.config['LXC_NODE'] = lxc_config.get('node')
     app.config['DEFAULT_STORAGE'] = lxc_config.get('default_storage')
     app.config['TIMEOUT'] = lxc_config.get('timeout_seconds', 30)
 
     # Load the rate limiting configuration
-    app.config['RATE_LIMITING'] = config.get('rate_limiting', {})
+    app.config['RATE_LIMITING'] = (config.get('rate_limiting') or {})
 
     # Load authentication configuration
-    app.config['AUTHENTICATION'] = config.get('authentication', {'enabled': False})
+    app.config['AUTHENTICATION'] = (config.get('authentication') or {'enabled': False})
 
     # Listen address. Defaults match the historical hard-coded values.
-    app.config['SERVER'] = config.get('server', {})
+    app.config['SERVER'] = (config.get('server') or {})
 
     # Flask settings
     app.secret_key = os.urandom(24)
     app.config['DEBUG'] = False
-    app.config['LOGGING'] = config.get('logging', {})
-    app.config['ERROR_HANDLING'] = config.get('error_handling', {})
+    app.config['LOGGING'] = (config.get('logging') or {})
+    app.config['ERROR_HANDLING'] = (config.get('error_handling') or {})
 
     return app

--- a/lxc_autoscale_ml/api/lxc_autoscale_api.py
+++ b/lxc_autoscale_ml/api/lxc_autoscale_api.py
@@ -71,6 +71,20 @@ ENDPOINTS = [
 ]
 
 
+def _failure_reason(response):
+    """A coarse, bounded label for a failed scaling action.
+
+    Every failure used to be recorded as reason="unknown", so the failure
+    counter carried no diagnostic value at all. Derived from the status code
+    rather than the message, to keep the label set finite.
+    """
+    status = response[1]
+    if status < 400:
+        return None
+    return {400: "invalid_request", 401: "unauthenticated", 403: "forbidden",
+            404: "not_found", 429: "rate_limited"}.get(status, "command_failed")
+
+
 KNOWN_METHODS = frozenset({'GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'})
 
 
@@ -141,7 +155,8 @@ def set_cores():
     cores = data['cores']
     logging.info(f"Setting {cores} cores for container {lxc_id}")
     response = scale_cpu(lxc_id, cores)
-    record_scaling_action(lxc_id, 'cpu', 'set', success=response[1] < 400)
+    record_scaling_action(lxc_id, 'cpu', 'set', success=response[1] < 400,
+                          failure_reason=_failure_reason(response))
     return response
 
 
@@ -155,7 +170,8 @@ def set_ram():
     memory = data['memory']
     logging.info(f"Setting {memory} MB RAM for container {lxc_id}")
     response = scale_ram(lxc_id, memory)
-    record_scaling_action(lxc_id, 'ram', 'set', success=response[1] < 400)
+    record_scaling_action(lxc_id, 'ram', 'set', success=response[1] < 400,
+                          failure_reason=_failure_reason(response))
     return response
 
 
@@ -169,7 +185,8 @@ def increase_storage():
     disk_size = data['disk_size']
     logging.info(f"Increasing storage by {disk_size} GB for container {lxc_id}")
     response = resize_storage(lxc_id, disk_size)
-    record_scaling_action(lxc_id, 'storage', 'increase', success=response[1] < 400)
+    record_scaling_action(lxc_id, 'storage', 'increase', success=response[1] < 400,
+                          failure_reason=_failure_reason(response))
     return response
 
 

--- a/lxc_autoscale_ml/api/lxc_management.py
+++ b/lxc_autoscale_ml/api/lxc_management.py
@@ -164,9 +164,17 @@ class LXCManager:
         return optional_int("cores"), optional_int("memory")
 
     def resize_storage(self, lxc_id, disk_size):
-        """Grow the root filesystem by `disk_size` GB."""
-        new_size = self.get_current_disk_size(lxc_id) + int(disk_size)
-        return self._run_command(["pct", "resize", lxc_id, "rootfs", f"{new_size}G"])
+        """Grow the root filesystem by `disk_size` GB.
+
+        `pct resize` accepts a relative `+NG`, so there is no need to read the
+        current size and compute an absolute target. The read-modify-write it
+        replaces both raced with any concurrent resize and silently lost up to
+        1 GiB, because get_current_disk_size floors to whole GB -- a container
+        on a 8.5G rootfs asked to grow by 2G ended up at 10G, not 10.5G, while
+        the response reported success.
+        """
+        return self._run_command(
+            ["pct", "resize", lxc_id, "rootfs", f"+{int(disk_size)}G"])
 
     # --- Snapshots -----------------------------------------------------------
 

--- a/lxc_autoscale_ml/model/async_api_client.py
+++ b/lxc_autoscale_ml/model/async_api_client.py
@@ -55,11 +55,22 @@ class AsyncAPIClient:
             # Give time for connections to close
             await asyncio.sleep(0.1)
 
+    @staticmethod
+    def _backoff(attempt: int, retry_delay: int | None) -> int:
+        """Exponential backoff, seeded from retry_logic.retry_delay when given.
+
+        The delay was hard-coded, so `retry_logic.retry_delay` governed only
+        apply_scaling despite the config documenting it for API calls generally.
+        """
+        base = 1 if retry_delay is None else max(1, int(retry_delay))
+        return base * (2 ** attempt)
+
     async def fetch_container_config(
         self,
         container_id: str,
         retry_count: int = 3,
-        circuit_breaker = None
+        circuit_breaker = None,
+        retry_delay: int | None = None,
     ) -> tuple[str, dict | None]:
         """
         Fetch configuration for a single container with retry logic.
@@ -96,7 +107,7 @@ class AsyncAPIClient:
                         elif response.status >= 500:
                             # Server error - retry
                             if attempt < retry_count - 1:
-                                wait_time = (2 ** attempt)  # Exponential backoff
+                                wait_time = self._backoff(attempt, retry_delay)
                                 logging.warning(
                                     f"Server error {response.status} for container {container_id}, "
                                     f"retry {attempt + 1}/{retry_count} in {wait_time}s"
@@ -133,7 +144,7 @@ class AsyncAPIClient:
                             f"Timeout fetching container {container_id}, "
                             f"retry {attempt + 1}/{retry_count}"
                         )
-                        await asyncio.sleep(2 ** attempt)
+                        await asyncio.sleep(self._backoff(attempt, retry_delay))
                     else:
                         logging.error(
                             f"Timeout fetching container {container_id} after {retry_count} attempts"
@@ -148,7 +159,7 @@ class AsyncAPIClient:
                             f"Network error for container {container_id}: {e}, "
                             f"retry {attempt + 1}/{retry_count}"
                         )
-                        await asyncio.sleep(2 ** attempt)
+                        await asyncio.sleep(self._backoff(attempt, retry_delay))
                     else:
                         logging.error(
                             f"Network error for container {container_id} after "
@@ -163,7 +174,9 @@ class AsyncAPIClient:
     async def fetch_batch_configs(
         self,
         container_ids: list[str],
-        circuit_breaker = None
+        circuit_breaker = None,
+        retry_count: int = 3,
+        retry_delay: int | None = None,
     ) -> dict[str, dict | None]:
         """
         Fetch configurations for multiple containers concurrently.
@@ -182,7 +195,9 @@ class AsyncAPIClient:
 
         # Create tasks for all containers
         tasks = [
-            self.fetch_container_config(cid, circuit_breaker=circuit_breaker)
+            self.fetch_container_config(cid, retry_count=retry_count,
+                                        retry_delay=retry_delay,
+                                        circuit_breaker=circuit_breaker)
             for cid in container_ids
         ]
 
@@ -214,6 +229,8 @@ async def fetch_all_container_configs(
     timeout: int = 5,
     max_concurrent: int = 10,
     api_key: str | None = None,
+    retry_count: int = 3,
+    retry_delay: int | None = None,
 ) -> dict[str, dict | None]:
     """
     Convenience function to fetch all container configs with proper session management.
@@ -229,7 +246,9 @@ async def fetch_all_container_configs(
         Dict mapping container_id to config
     """
     async with AsyncAPIClient(api_url, timeout, max_concurrent, api_key) as client:
-        return await client.fetch_batch_configs(container_ids, circuit_breaker)
+        return await client.fetch_batch_configs(
+            container_ids, circuit_breaker, retry_count=retry_count,
+            retry_delay=retry_delay)
 
 
 def fetch_container_configs_sync(
@@ -239,6 +258,8 @@ def fetch_container_configs_sync(
     timeout: int = 5,
     max_concurrent: int = 10,
     api_key: str | None = None,
+    retry_count: int = 3,
+    retry_delay: int | None = None,
 ) -> dict[str, dict | None]:
     """
     Synchronous wrapper for async batch fetch - for use in sync code.
@@ -263,7 +284,8 @@ def fetch_container_configs_sync(
                 future = executor.submit(
                     asyncio.run,
                     fetch_all_container_configs(
-                        container_ids, api_url, circuit_breaker, timeout, max_concurrent, api_key
+                        container_ids, api_url, circuit_breaker, timeout, max_concurrent, api_key,
+                        retry_count, retry_delay
                     )
                 )
                 return future.result()
@@ -271,13 +293,15 @@ def fetch_container_configs_sync(
             # Use existing loop
             return loop.run_until_complete(
                 fetch_all_container_configs(
-                    container_ids, api_url, circuit_breaker, timeout, max_concurrent, api_key
+                    container_ids, api_url, circuit_breaker, timeout, max_concurrent, api_key,
+                        retry_count, retry_delay
                 )
             )
     except RuntimeError:
         # No event loop, create new one
         return asyncio.run(
             fetch_all_container_configs(
-                container_ids, api_url, circuit_breaker, timeout, max_concurrent, api_key
+                container_ids, api_url, circuit_breaker, timeout, max_concurrent, api_key,
+                        retry_count, retry_delay
             )
         )

--- a/lxc_autoscale_ml/model/lxc_autoscale_ml.py
+++ b/lxc_autoscale_ml/model/lxc_autoscale_ml.py
@@ -195,6 +195,10 @@ def run_cycle(config, circuit_breaker=None):
         timeout=api_config.get("timeout_seconds", api_config.get("timeout", 5)),
         max_concurrent=api_config.get("max_concurrent", 10),
         api_key=api_config.get("api_key"),
+        # retry_logic is documented as governing API calls; it used to reach
+        # only apply_scaling.
+        retry_count=config.get("retry_logic", {}).get("max_retries", 3),
+        retry_delay=config.get("retry_logic", {}).get("retry_delay"),
     )
 
     batch_duration = time.monotonic() - batch_start

--- a/tests/test_lxc_management.py
+++ b/tests/test_lxc_management.py
@@ -119,9 +119,20 @@ class TestDiskSize:
         with pytest.raises(RuntimeError, match="current disk size"):
             manager.get_current_disk_size(104)
 
-    def test_resize_adds_to_the_current_size(self, manager, pct):
+    def test_resize_grows_by_a_relative_amount(self, manager, pct):
+        """`pct resize` takes `+NG`. The read-modify-write this replaces raced
+        with any concurrent resize and silently lost up to 1 GiB, because the
+        current size was floored to whole GB."""
         manager.resize_storage(104, 4)
-        pct.assert_ran("pct", "resize", 104, "rootfs", "12G")
+        pct.assert_ran("pct", "resize", 104, "rootfs", "+4G")
+        # No read of the current size at all.
+        assert not any(argv[:2] == ["pct", "config"] for argv in pct)
+
+    def test_a_fractional_current_size_is_not_lost(self, manager, pct):
+        """8.5G + 2G used to become 10G while reporting success."""
+        pct.output = "rootfs: local-lvm:vm-104-disk-0,size=8.5G\n"
+        manager.resize_storage(104, 2)
+        pct.assert_ran("pct", "resize", 104, "rootfs", "+2G")
 
 
 class TestCommandShapes:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -232,3 +232,56 @@ class TestMetricLabels:
         body = client.get("/metrics").get_data(as_text=True)
         assert "PROPFIND" not in body
         assert 'method="other"' in body
+
+
+class TestEmptyConfigSections:
+    """A section written but left empty parses to None, and
+    `.get(key, default)` returns that stored None rather than the default --
+    which surfaced as a raw HTML 500 on every request. The gunicorn config, the
+    monitor and the model loader all guarded this; the API did not."""
+
+    @pytest.mark.parametrize("section", [
+        "lxc", "rate_limiting", "authentication", "server", "logging", "error_handling",
+    ])
+    def test_an_empty_section_does_not_break_startup(self, section, tmp_path, monkeypatch):
+        import config as api_config
+
+        base = {
+            "lxc": {"node": "pve", "timeout_seconds": 5},
+            "rate_limiting": {"enabled": False},
+            "authentication": {"enabled": False},
+            "server": {}, "logging": {}, "error_handling": {},
+        }
+        base[section] = None
+        app = api_config.create_app(base)
+        assert app.config["TIMEOUT"] in (5, 30)
+
+    def test_a_wholly_empty_file_is_tolerated(self, tmp_path, monkeypatch):
+        import config as api_config
+
+        path = tmp_path / "api.yaml"
+        path.write_text("# nothing here\n")
+        monkeypatch.setenv("LXC_AUTOSCALE_API_CONFIG", str(path))
+        assert api_config.load_config() == {}
+
+
+class TestScalingFailureLabels:
+    def test_a_failure_carries_a_reason(self, client, pct):
+        """Every failure used to be labelled reason="unknown", so the failure
+        counter carried no diagnostic value."""
+        metrics = pytest.importorskip("metrics")
+        if not metrics.PROMETHEUS_AVAILABLE:
+            pytest.skip("prometheus_client is not installed")
+
+        pct.responses = {("pct", "set"): RuntimeError("container is locked")}
+        client.post("/scale/cores", json={"lxc_id": 104, "cores": 8})
+        body = client.get("/metrics").get_data(as_text=True)
+        assert 'reason="command_failed"' in body
+
+    def test_the_reason_label_set_is_finite(self):
+        import lxc_autoscale_api as api
+
+        reasons = {api._failure_reason((None, code))
+                   for code in (200, 400, 401, 403, 404, 429, 500, 502, 503)}
+        assert None in reasons
+        assert len(reasons - {None}) <= 6, "the reason label must stay bounded"


### PR DESCRIPTION
Stacked on #45. The last of the audit's actionable findings.

## An empty configuration section returned a raw HTML 500 on every request

A section written but left blank parses to `None`, and `.get(key, default)`
hands back that stored `None` rather than the default. The gunicorn config, the
monitor and the model's loader all already guarded this — only the API's did
not.

## `/scale/storage/increase` silently lost up to 1 GiB

It read the current size, **floored it to whole GB**, and wrote back an absolute
target. A container on an 8.5G rootfs asked to grow by 2G ended up at 10G, not
10.5G — and the response reported success.

`pct resize` takes a relative `+NG`, which removes the read-modify-write, its
rounding, and its race with any concurrent resize.

## `retry_logic` did not govern what it says it governs

`retry_count` was a default parameter `fetch_batch_configs` never passed, and
the backoff was a hard-coded `2 ** attempt`. So the documented `max_retries` and
`retry_delay` reached only `apply_scaling`.

## Every scaling failure was labelled `reason="unknown"`

The failure counter carried no diagnostic value at all. The reason now comes
from the status code rather than the message, which keeps the label set finite —
a test pins that.

## One deliberately NOT fixed in code

**Rate limiting does not work behind the reverse proxy the docs prescribe.** The
limiter exempts `127.0.0.1`, which is exactly what `proxy_pass` makes every
request look like.

Installing a proxy-header fixer would be **worse**: with `server.host: 0.0.0.0`
any client reaching the port directly could then spoof
`X-Forwarded-For: 127.0.0.1` and exempt itself. Doing it properly needs a
trusted-proxy list the API does not have yet.

Both nginx recipes now say so and point at nginx's own `limit_req_zone`.

## Still open, deliberately

These came out of the audit and are **not** in this PR, because each is a design
decision or a contract change rather than a defect to patch:

- the IsolationForest verdict does not affect any scaling decision — it is
  logged and discarded. Either wire it in or say so in the docs; both are
  choices for the owner.
- the metrics file is a full read-modify-write every cycle (~9.6 GB/day at 20
  containers after #43). Append-only JSONL fixes it but changes the contract
  between the monitor and the model.
- `pct clone`/`destroy` can outlive the per-command timeout, which kills the CLI
  but not the PVE worker it forked. Doing this properly means polling the UPID.
- cumulative `/proc` counters are fed to the model as features, and the scaler
  is fitted fleet-wide. Only matters if the verdict is ever wired in.

511 tests. `ruff` and `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
