### PR TITLE
fix(deps): close the pytest tmpdir advisory

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@
 # the tests exercise the data pipeline and the metrics collector too.
 -r requirements.txt
 
-pytest==8.4.2
+pytest==9.1.1
 ruff==0.14.4


### PR DESCRIPTION
Closes GHSA-6w46-j5rx-g56g (pytest tmpdir handling, affects < 9.0.3).

Development-only — pytest is not deployed to a Proxmox host — but it is a
one-line change and it clears the last open advisory outside the VitePress
toolchain, which SECURITY.md documents as accepted with reasons.

Verified: the full suite (511 tests) passes on 9.1.1 unchanged.

Merging this before tagging v1.4.0 so the release ships with no unexplained
open alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)