### PR TITLE
seo(docs): genera la sitemap.xml (VitePress)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,6 +4,9 @@ export default defineConfig({
   title: 'LXC AutoScale ML',
   description: 'ML-powered autoscaling for Proxmox LXC containers',
   base: '/proxmox-lxc-autoscale-ml/',
+  // The hostname carries the base path on purpose: VitePress joins it with each
+  // page's route, so without it every URL in the sitemap would point at a 404.
+  sitemap: { hostname: 'https://fabriziosalmi.github.io/proxmox-lxc-autoscale-ml/' },
 
   head: [
     // Everything this site loads is first-party. 'unsafe-inline' is required


### PR DESCRIPTION
VitePress sa generare la sitemap da solo: serve solo `sitemap.hostname`.

**L'hostname deve portarsi dietro il base path.** VitePress lo unisce alla rotta di ogni pagina, quindi senza di esso ogni URL della sitemap punterebbe a un 404 ([docs](https://vitepress.dev/guide/sitemap-generation#options)).

**Verificato costruendo davvero il sito**, non solo leggendo la config: **20 URL** generati, tutti con il base corretto. Primo URL della sitemap: `https://fabriziosalmi.github.io/proxmox-lxc-autoscale-ml/components/api`

**Perché conta qui:** la home linka **8** pagine, il sito ne ha **20**. La differenza Google la trova solo per caso.

Tre righe in `docs/.vitepress/config.mts`, nessun file nuovo, nessuna dipendenza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
